### PR TITLE
Spell check

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^README\.Rmd$
 ^README-.*\.png$
 ^data-raw$
+^\.github$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     utils,
     readr
 Suggests: 
+    spelling,
     covr,
     here,
     testthat (>= 3.0.0)
@@ -40,3 +41,4 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
 Config/testthat/edition: 3
+Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,6 @@ Suggests:
     testthat (>= 3.0.0)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Config/testthat/edition: 3
 Language: en-GB

--- a/R/chi.R
+++ b/R/chi.R
@@ -125,7 +125,7 @@ sub_num <- function(x, num) {
 #'
 #' The first six digits of a CHI number are a patient's date of birth in
 #' DD/MM/YY format. The first digit of a CHI number must, therefore, be 3 or
-#' less. Depending on the source, CHI numbers are sometimes mising a leading
+#' less. Depending on the source, CHI numbers are sometimes missing a leading
 #' zero.
 #'
 #' While a CHI number is made up exclusively of numeric digits, it cannot be
@@ -175,8 +175,8 @@ chi_pad <- function(x) {
 #' @param chi_number a CHI number or a vector of CHI numbers with \code{character} class.
 #' @param male_value,female_value optionally supply custom values for Male and Female. Note
 #' that that these must be of the same class.
-#' @param as_factor logical, optionally return as a factor with lables \code{'Male'}
-#' and \code{'Female'}. Note that this will overide any custom values supplied with
+#' @param as_factor logical, optionally return as a factor with labels \code{'Male'}
+#' and \code{'Female'}. Note that this will override any custom values supplied with
 #' \code{male_value} or \code{female_value}.
 #' @param chi_check logical, optionally skip checking the CHI for validity which will be
 #' faster but should only be used if you have previously checked the CHI(s).

--- a/R/data.R
+++ b/R/data.R
@@ -7,7 +7,7 @@
 #' Boards, Council Areas, Health and Social Care Partnerships, Intermediate
 #' Zones, Data Zones (2001 and 2011), Electoral Wards, Scottish Parliamentary
 #' Constituencies, UK Parliamentary Constituencies, Travel to work areas,
-#' National Parks, Commmunity Health Partnerships, Localities (S19),
+#' National Parks, Community Health Partnerships, Localities (S19),
 #' Settlements (S20) and Scotland.
 #'
 #' @seealso The script used to create the \code{area_lookup} dataset on

--- a/R/match_area.R
+++ b/R/match_area.R
@@ -20,7 +20,7 @@
 #' Areas, Health and Social Care Partnerships, Intermediate Zones, Data Zones
 #' (2001 and 2011), Electoral Wards, Scottish Parliamentary Constituencies,
 #' UK Parliamentary Constituencies, Travel to work areas, National Parks,
-#' Commmunity Health Partnerships, Localities (S19), Settlements (S20) and
+#' Community Health Partnerships, Localities (S19), Settlements (S20) and
 #' Scotland.
 #'
 #' \code{match_area} returns a non-NA value only when an exact match is present

--- a/man/area_lookup.Rd
+++ b/man/area_lookup.Rd
@@ -26,7 +26,7 @@ It is used within \code{\link{match_area}}.
 Boards, Council Areas, Health and Social Care Partnerships, Intermediate
 Zones, Data Zones (2001 and 2011), Electoral Wards, Scottish Parliamentary
 Constituencies, UK Parliamentary Constituencies, Travel to work areas,
-National Parks, Commmunity Health Partnerships, Localities (S19),
+National Parks, Community Health Partnerships, Localities (S19),
 Settlements (S20) and Scotland.
 }
 \seealso{

--- a/man/chi_pad.Rd
+++ b/man/chi_pad.Rd
@@ -21,7 +21,7 @@ each patient on the index.
 
 The first six digits of a CHI number are a patient's date of birth in
 DD/MM/YY format. The first digit of a CHI number must, therefore, be 3 or
-less. Depending on the source, CHI numbers are sometimes mising a leading
+less. Depending on the source, CHI numbers are sometimes missing a leading
 zero.
 
 While a CHI number is made up exclusively of numeric digits, it cannot be

--- a/man/match_area.Rd
+++ b/man/match_area.Rd
@@ -37,7 +37,7 @@ It can account for geography codes pertaining to Health Boards, Council
 Areas, Health and Social Care Partnerships, Intermediate Zones, Data Zones
 (2001 and 2011), Electoral Wards, Scottish Parliamentary Constituencies,
 UK Parliamentary Constituencies, Travel to work areas, National Parks,
-Commmunity Health Partnerships, Localities (S19), Settlements (S20) and
+Community Health Partnerships, Localities (S19), Settlements (S20) and
 Scotland.
 
 \code{match_area} returns a non-NA value only when an exact match is present

--- a/man/sex_from_chi.Rd
+++ b/man/sex_from_chi.Rd
@@ -18,8 +18,8 @@ sex_from_chi(
 \item{male_value, female_value}{optionally supply custom values for Male and Female. Note
 that that these must be of the same class.}
 
-\item{as_factor}{logical, optionally return as a factor with lables \code{'Male'}
-and \code{'Female'}. Note that this will overide any custom values supplied with
+\item{as_factor}{logical, optionally return as a factor with labels \code{'Male'}
+and \code{'Female'}. Note that this will override any custom values supplied with
 \code{male_value} or \code{female_value}.}
 
 \item{chi_check}{logical, optionally skip checking the CHI for validity which will be

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,0 +1,3 @@
+if(requireNamespace('spelling', quietly = TRUE))
+  spelling::spell_check_test(vignettes = TRUE, error = FALSE,
+                             skip_on_cran = TRUE)


### PR DESCRIPTION
I was writing some stuff and realised I'd made some typos, and that spell check wasn't enabled in the package yet.

This PR enables {[spelling](https://docs.ropensci.org/spelling/#automate-package-spell-checking)} which will highlight possible spelling errors whenever the package is tested. 

I fixed a few obvious spelling mistakes but I didn't commit a wordlist which should probably be done to reduce the false positives.