### PR TITLE
Add cli, and update `format_postcode` to use it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ BugReports: https://github.com/Health-SocialCare-Scotland/phsmethods/issues
 Depends:
     R (>= 2.10)
 Imports:
+    cli,
     dplyr,
     gdata,
     glue,

--- a/tests/testthat/_snaps/rename.md
+++ b/tests/testthat/_snaps/rename.md
@@ -59,13 +59,14 @@
       expect_equal(unique(formatted_hampden), "G42 9BA")
       expect_true(is.na(suppressWarnings(postcode("G2?QE"))))
       expect_warning(postcode(c("G207AL", "G2O07AL")))
-    Warning <simpleWarning>
-      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA. The standard format is:
-      • 1 or 2 letters, followed by
-      • 1 number, followed by
-      • 1 optional letter or number, followed by
-      • 1 number, followed by
-      • 2 letters
+    Warning <rlang_warning>
+      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
+      The standard format is:
+      * 1 or 2 letters, followed by
+      * 1 number, followed by
+      * 1 optional letter or number, followed by
+      * 1 number, followed by
+      * 2 letters
     Code
       expect_equal(suppressWarnings(postcode(c("EH7 5QG", NA, "EH11 2NL", "EH5 2HF*"))),
       c("EH7 5QG", NA, "EH112NL", NA))


### PR DESCRIPTION
I was trying to fix an issue with the warning from `format_postode` being garbled when used within `mutate`. 

Since I can't do a reprex on the RStudio server I'll add some screen grabs!

Expected output with a vector:
![image](https://user-images.githubusercontent.com/5982260/184350076-07bcd940-2260-4e6f-81e6-75715165339f.png)

Garbled output when used within mutate (probably the standard use-case)
![image](https://user-images.githubusercontent.com/5982260/184350271-8b1bcab3-c444-4ab0-96cc-d0cdb4730f15.png)

I thought that using [cli](https://cli.r-lib.org/) to format the warning might fix this issue, it turned out that it doesn't and after testing on RStudio Desktop v1.3 and seeing that the warning looks fine, I now suspect that it's the old version of RStudio we have on the server which is actually causing the issue.

Since I'd already done the work to use {cli} I thought I'd open this PR, as the cli formatted warnings do look a bit nicer, and are much easier to read thanks to all the built-in formatting.

It would be a pretty simple job to roll out the usage of cli to the other messages, warnings and errors in the package too if you wanted.

