### PR TITLE
Use the `cli` package for all errors, warnings and messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,47 +2,50 @@ Package: phsmethods
 Title: Standard Methods for use in Public Health Scotland
 Version: 0.2.1
 Authors@R: c(
-    person("David", "Caldwell", email = "David.Caldwell@phs.scot", role = c("aut", "cre")),
-    person("Lucinda", "Lawrie", email = "Lucinda.Lawrie@phs.scot", role = "rev"),
-    person("Jack", "Hannah", email = "jack.hannah2@phs.scot", role = "aut"),
-    person("Tina", "Fu", email = "Yuyan.Fu2@phs.scot", role = "aut"),
-    person("Ciara", "Gribben", email = "Ciara.Gribben@phs.scot", role = "aut"),
-    person("Chris", "Deans", email = "Chris.Deans2@phs.scot", role = "aut"),
-    person("Jaime", "Villacampa", email = "Jaime.Villacampa@phs.scot", role = "aut"),
-    person("Graeme", "Gowans", email = "Graeme.Gowans@phs.scot", role = "aut"),
+    person("David", "Caldwell", , "David.Caldwell@phs.scot", role = c("aut", "cre")),
+    person("Lucinda", "Lawrie", , "Lucinda.Lawrie@phs.scot", role = "rev"),
+    person("Jack", "Hannah", , "jack.hannah2@phs.scot", role = "aut"),
+    person("Tina", "Fu", , "Yuyan.Fu2@phs.scot", role = "aut"),
+    person("Ciara", "Gribben", , "Ciara.Gribben@phs.scot", role = "aut"),
+    person("Chris", "Deans", , "Chris.Deans2@phs.scot", role = "aut"),
+    person("Jaime", "Villacampa", , "Jaime.Villacampa@phs.scot", role = "aut"),
+    person("Graeme", "Gowans", , "Graeme.Gowans@phs.scot", role = "aut"),
     person("Alice", "Byers", role = "ctb"),
-    person("Alan", "Yeung", email = "Alan.Yeung@phs.scot", role = "ctb"),
-    person("James", "McMahon", email = "James.McMahon@phs.scot", role = "aut"),
-    person("Nicolaos", "Christofidis", email = "nicolaos.christofidis@phs.scot", role = "aut")
-    )
-Description: Bespoke functions for commonly undertaken analytical tasks in Public Health Scotland.
+    person("Alan", "Yeung", , "Alan.Yeung@phs.scot", role = "ctb"),
+    person("James", "McMahon", , "James.McMahon@phs.scot", role = "aut"),
+    person("Nicolaos", "Christofidis", , "nicolaos.christofidis@phs.scot", role = "aut")
+  )
+Description: Bespoke functions for commonly undertaken analytical tasks in
+    Public Health Scotland.
 License: GPL (>= 2)
-URL: https://github.com/Health-SocialCare-Scotland/phsmethods, https://public-health-scotland.github.io/phsmethods/
-BugReports: https://github.com/Health-SocialCare-Scotland/phsmethods/issues
+URL: https://github.com/Health-SocialCare-Scotland/phsmethods,
+    https://public-health-scotland.github.io/phsmethods/
+BugReports: 
+    https://github.com/Health-SocialCare-Scotland/phsmethods/issues
 Depends:
     R (>= 2.10)
 Imports:
     cli,
     dplyr,
     gdata,
-    glue,
+    lifecycle,
     lubridate,
     magrittr,
     purrr,
+    readr,
     rlang,
     stringr,
     tibble,
-    utils,
-    readr,
-    lifecycle
+    utils
 Suggests: 
-    spelling,
     covr,
     here,
+    spelling,
     testthat (>= 3.0.0)
-Encoding: UTF-8
-LazyData: true
-RoxygenNote: 7.2.0
+RdMacros: 
+    lifecycle
 Config/testthat/edition: 3
+Encoding: UTF-8
 Language: en-GB
-RdMacros: lifecycle
+LazyData: true
+RoxygenNote: 7.2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - Improve "Using phsmethods" section in readme to be shorter and more accessible. 
 
-- Fix the warning message in `format_postcode()` using package "cli". 
+- Update all errors, warnings and messages to use the `cli` package. 
 
 # phsmethods 0.2.1 (2022-02-11)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# phsmethods 0.2.2 (2022-08-29)
+
+- Improve `chi_check()` function to make it more efficient and run faster.
+
+- Improve "Using phsmethods" section in readme to be shorter and more accessible. 
+
+- Fix the warning message in `format_postcode()` using package "cli". 
+
 # phsmethods 0.2.1 (2022-02-11)
 
 - Three functions renamed to improve code clarity: `postcode()` to `format_postcode()`; `age_group()` to `create_age_groups()`; `fin_year()` to `extract_fin_year()`. The old functions will still work but will produce a warning. After a reasonable amount of time they will be removed completely.

--- a/R/age_calculate.R
+++ b/R/age_calculate.R
@@ -31,11 +31,11 @@
 age_calculate <- function(start, end = if (lubridate::is.Date(start)) Sys.Date() else Sys.time(),
                           units = c("years", "months"), round_down = TRUE) {
   if (!inherits(start, c("Date", "POSIXt"))) {
-    stop("The start date must have Date or POSIXct or POSIXlt class")
+    cli::cli_abort("{.arg start} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(start)}} vector.")
   }
 
   if (!inherits(end, c("Date", "POSIXt"))) {
-    stop("The end date must have Date or POSIXct or POSIXlt class")
+    cli::cli_abort("{.arg end} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(end)}} vector.")
   }
 
   units <- match.arg(tolower(units), c("years", "months"))

--- a/R/age_calculate.R
+++ b/R/age_calculate.R
@@ -51,9 +51,23 @@ age_calculate <- function(start, end = if (lubridate::is.Date(start)) Sys.Date()
 
   age <- age_interval / unit_time
 
-  if (any(age < 0, na.rm = TRUE)) warning("There are ages less than 0")
-  if (units == "years" & any(age > 130, na.rm = TRUE)) warning("There are ages greater than 130 years")
-  if (units == "months" & any(age / 12 > 130, na.rm = TRUE)) warning("There are ages greater than 130 years")
-  if (round_down) age <- trunc(age)
+  if (any(age < 0, na.rm = TRUE)) {
+    cli::cli_warn(c("!" = "There are ages less than 0."))
+  }
+
+  if (units == "years") {
+    if (any(age > 130, na.rm = TRUE)) {
+      cli::cli_warn(c("!" = "There are ages greater than 130 years."))
+    }
+  } else if (units == "months") {
+    if (any(age / 12 > 130, na.rm = TRUE)) {
+      cli::cli_warn(c("!" = "There are ages greater than 130 years."))
+    }
+  }
+
+  if (round_down) {
+    age <- trunc(age)
+  }
+
   return(age)
 }

--- a/R/chi_check.R
+++ b/R/chi_check.R
@@ -60,7 +60,7 @@
 
 chi_check <- function(x) {
   if (!inherits(x, "character")) {
-    cli::cli_abort("{.arg x} must be a {.cls character} vector, not a {.cls {class(x)}} vector.")
+    cli::cli_abort("The input must be a {.cls character} vector, not a {.cls {class(x)}} vector.")
   }
 
   # Calculate the number of characters

--- a/R/chi_check.R
+++ b/R/chi_check.R
@@ -60,7 +60,7 @@
 
 chi_check <- function(x) {
   if (!inherits(x, "character")) {
-    stop("The input must be of character class")
+    cli::cli_abort("{.arg x} must be a {.cls character} vector, not a {.cls {class(x)}} vector.")
   }
 
   # Calculate the number of characters

--- a/R/chi_pad.R
+++ b/R/chi_pad.R
@@ -28,7 +28,7 @@
 
 chi_pad <- function(x) {
   if (!inherits(x, "character")) {
-    cli::cli_abort("{.arg x} must be a {.cls character} vector, not a {.cls {class(x)}} vector.")
+    cli::cli_abort("The input must be a {.cls character} vector, not a {.cls {class(x)}} vector.")
   }
 
   # Add a leading zero to any string comprised of nine numeric digits

--- a/R/chi_pad.R
+++ b/R/chi_pad.R
@@ -28,7 +28,7 @@
 
 chi_pad <- function(x) {
   if (!inherits(x, "character")) {
-    stop("The input must be of character class")
+    cli::cli_abort("{.arg x} must be a {.cls character} vector, not a {.cls {class(x)}} vector.")
   }
 
   # Add a leading zero to any string comprised of nine numeric digits

--- a/R/dob_from_chi.R
+++ b/R/dob_from_chi.R
@@ -40,18 +40,24 @@
 dob_from_chi <- function(chi_number, min_date = NULL, max_date = NULL, chi_check = TRUE) {
 
   # Do type checking on the params
-  stopifnot(typeof(chi_number) == "character")
+  if (!inherits(chi_number, "character")) {
+    cli::cli_abort("{.arg chi_number} must be a {.cls character} vector, not a {.cls {class(chi_number)}} vector.")
+  }
 
   if (!is.null(min_date) & !inherits(min_date, c("Date", "POSIXct"))) {
-    stop("min_date must have Date or POSIXct class")
+    cli::cli_abort("{.arg min_date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(min_date)}} vector.")
   }
 
   if (!is.null(max_date) & !inherits(max_date, c("Date", "POSIXct"))) {
-    stop("max_date must have Date or POSIXct class")
+    cli::cli_abort("{.arg max_date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(max_date)}} vector.")
   }
 
   # min and max date are in a reasonable range
-  if (!is.null(min_date) & !is.null(max_date)) stopifnot(min_date <= max_date)
+  if (!is.null(min_date) & !is.null(max_date)) {
+    if (max_date < min_date) {
+      cli::cli_abort("{.arg max_date}, must always be greater than or equal to {.arg min_date}.")
+    }
+  }
 
   # Default the max_date to today (person can't be born after today)
   if (is.null(max_date)) max_date <- Sys.Date()
@@ -169,16 +175,24 @@ dob_from_chi <- function(chi_number, min_date = NULL, max_date = NULL, chi_check
 age_from_chi <- function(chi_number, ref_date = NULL, min_age = 0, max_age = NULL, chi_check = TRUE) {
 
   # Do type checking on the params
-  stopifnot(typeof(chi_number) == "character")
+  if (!inherits(chi_number, "character")) {
+    cli::cli_abort("{.arg chi_number} must be a {.cls character} vector, not a {.cls {class(chi_number)}} vector.")
+  }
 
   if (!is.null(ref_date) & !inherits(ref_date, c("Date", "POSIXct"))) {
-    stop("ref_date must have Date or POSIXct class")
+    cli::cli_abort("{.arg ref_date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(ref_date)}} vector.")
   }
 
   # min and max ages are in a reasonable range
-  stopifnot(min_age >= 0)
+  if (min_age < 0) {
+    cli::cli_abort("{.arg min_age} must be a positive integer.")
+  }
 
-  if (!is.null(max_age)) stopifnot(max_age >= min_age)
+  if (!is.null(max_age)) {
+    if (max_age < min_age) {
+      cli::cli_abort("{.arg max_age}, must always be greater than or equal to {.arg min_age}.")
+    }
+  }
 
   if (is.null(ref_date)) ref_date <- Sys.Date()
 

--- a/R/dob_from_chi.R
+++ b/R/dob_from_chi.R
@@ -84,7 +84,7 @@ dob_from_chi <- function(chi_number, min_date = NULL, max_date = NULL, chi_check
     new_na_count <- sum(is.na(chi_number)) - na_count
 
     if (new_na_count > 0) {
-      message(glue::glue("{format(new_na_count, big.mark = ',')} CHI number{ifelse(new_na_count > 1, 's were', ' was')} invalid and will be given NA for DoB"))
+      cli::cli_alert_warning(("{format(new_na_count, big.mark = ',')}{cli::qty(new_na_count)} CHI number{?s} {?is/are} invalid and will be given {.val NA} for {?its/their} Date{?s} of Birth."))
     }
   }
 
@@ -123,9 +123,11 @@ dob_from_chi <- function(chi_number, min_date = NULL, max_date = NULL, chi_check
   new_na_count <- sum(is.na(guess_dob)) - na_count
 
   if (new_na_count > 0) {
-    message(glue::glue("{format(new_na_count, big.mark = ',')} CHI number{ifelse(new_na_count > 1, 's produced ambiguous dates', ' produced an ambiguous date')} and will be given NA for DoB, if possible try different values for min_date and/or max_date"))
+    cli::cli_inform(c(
+      "!" = "{format(new_na_count, big.mark = ',')}{cli::qty(new_na_count)} CHI number{?s} produced {?an/} ambiguous date{?s} and will be given {.val NA} for {?its/their} Date{?s} of Birth.",
+      "v" = "Try different values for {.arg min_date} and/or {.arg max_date}."
+    ))
   }
-
 
   return(guess_dob)
 }

--- a/R/dob_from_chi.R
+++ b/R/dob_from_chi.R
@@ -54,7 +54,7 @@ dob_from_chi <- function(chi_number, min_date = NULL, max_date = NULL, chi_check
 
   # min and max date are in a reasonable range
   if (!is.null(min_date) & !is.null(max_date)) {
-    if (max_date < min_date) {
+    if (any(max_date < min_date)) {
       cli::cli_abort("{.arg max_date}, must always be greater than or equal to {.arg min_date}.")
     }
   }
@@ -191,7 +191,7 @@ age_from_chi <- function(chi_number, ref_date = NULL, min_age = 0, max_age = NUL
   }
 
   if (!is.null(max_age)) {
-    if (max_age < min_age) {
+    if (any(max_age < min_age)) {
       cli::cli_abort("{.arg max_age}, must always be greater than or equal to {.arg min_age}.")
     }
   }

--- a/R/dob_from_chi.R
+++ b/R/dob_from_chi.R
@@ -69,7 +69,7 @@ dob_from_chi <- function(chi_number, min_date = NULL, max_date = NULL, chi_check
   if (any(max_date > Sys.Date())) {
     to_replace <- max_date > Sys.Date()
     max_date[to_replace] <- Sys.Date()
-    warning("any max_date where it is a future date is changed to date of today")
+    cli::cli_warn(c("!" = "Any {.arg max_date} values which are in the future will be set to today: {.val {Sys.Date()}}."))
   }
 
   # Default the min_date to 1 Jan 1900

--- a/R/extract_fin_year.R
+++ b/R/extract_fin_year.R
@@ -17,7 +17,7 @@
 #' @export
 extract_fin_year <- function(date) {
   if (!inherits(date, c("Date", "POSIXct"))) {
-    stop("The input must have Date or POSIXct class")
+    cli::cli_abort("{.arg date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(date)}} vector.")
   }
 
   # Simply converting all elements of the input vector resulted in poor

--- a/R/file_size.R
+++ b/R/file_size.R
@@ -74,14 +74,12 @@
 #' @export
 
 file_size <- function(filepath = getwd(), pattern = NULL) {
-
   if (!file.exists(filepath)) {
-    stop("A valid filepath must be supplied")
+    cli::cli_abort("A valid {.arg filepath} must be supplied.")
   }
 
   if (!inherits(pattern, c("character", "NULL"))) {
-    stop("A specified pattern must be of character class in order to be ",
-         "evaluated as a regular expression")
+    cli::cli_abort("{.arg pattern} must be a {.cls character}, not a {.cls {class(pattern)}}.")
   }
 
   x <- dir(path = filepath, pattern = pattern)

--- a/R/match_area.R
+++ b/R/match_area.R
@@ -56,24 +56,18 @@ match_area <- function(x) {
 
   # Calculate the number of non-NA input geography codes which are not 9
   # characters in length or one of the exceptions
-  n <- length(x[!is.na(x)][nchar(x[!is.na(x)]) != 9 &
+  n_not_9_char <- length(x[!is.na(x)][nchar(x[!is.na(x)]) != 9 &
                              !x[!is.na(x)] %in% sprintf("RA270%d", seq(1:4))])
 
-  # If n is one, the warning message describing the number of non-NA codes
-  # which are not length 9 or one of the exceptions should use singular verbs
-  # Otherwise, use plural ones
-  singular <- "code is"
-  multiple <- "codes are"
-
-  if (n > 0) {
-    warning(glue::glue("{n} non-NA input geography ",
-                       "{ifelse(n == 1, singular, multiple)} not 9 characters ",
-                       "in length and will return an NA. The only allowed ",
-                       "codes with a differing number of characters are:\n",
-                       "\U2022 RA2701: No Fixed Abode\n",
-                       "\U2022 RA2702: Rest of UK (Outside Scotland)\n",
-                       "\U2022 RA2703: Outside the UK\n",
-                       "\U2022 RA2704: Unknown Residency"))
+  if (n_not_9_char > 0) {
+    cli::cli_warn(c(
+      "!" = "{n_not_9_char} non-NA input geograph{?y/ies} {?is/are} not 9 characters in length and will return {.val NA}.",
+      "The only allowed codes with a differing number of characters are:",
+      "*" = "{.val RA2701} - No Fixed Abode",
+      "*" = "{.val RA2702} - Rest of UK (Outside Scotland)",
+      "*" = "{.val RA2703} - Outside the UK",
+      "*" = "{.val RA2704} - Unknown Residency"
+    ))
   }
 
   # Load area code to name lookup

--- a/R/qtr.R
+++ b/R/qtr.R
@@ -36,7 +36,7 @@
 #' qtr_end(x, format = "short")
 #' qtr_next(x)
 #' qtr_prev(x, format = "short")
-
+#'
 #' @export
 #' @rdname qtr
 qtr <- function(date, format = c("long", "short")) {
@@ -44,7 +44,7 @@ qtr <- function(date, format = c("long", "short")) {
   format <- match.arg(format)
 
   if (!inherits(date, c("Date", "POSIXct"))) {
-    stop("The input must have Date or POSIXct class")
+    cli::cli_abort("{.arg date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(date)}} vector.")
   }
 
   quarter_num <- lubridate::quarter(date)
@@ -80,7 +80,7 @@ qtr_end <- function(date, format = c("long", "short")) {
   format <- match.arg(format)
 
   if (!inherits(date, c("Date", "POSIXct"))) {
-    stop("The input must have Date or POSIXct class")
+    cli::cli_abort("{.arg date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(date)}} vector.")
   }
 
   quarter_num <- lubridate::quarter(date)
@@ -116,7 +116,7 @@ qtr_next <- function(date, format = c("long", "short")) {
   format <- match.arg(format)
 
   if (!inherits(date, c("Date", "POSIXct"))) {
-    stop("The input must have Date or POSIXct class")
+    cli::cli_abort("{.arg date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(date)}} vector.")
   }
 
   quarter_num <- lubridate::quarter(date)
@@ -152,7 +152,7 @@ qtr_prev <- function(date, format = c("long", "short")) {
   format <- match.arg(format)
 
   if (!inherits(date, c("Date", "POSIXct"))) {
-    stop("The input must have Date or POSIXct class")
+    cli::cli_abort("{.arg date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(date)}} vector.")
   }
 
   quarter_num <- lubridate::quarter(date)

--- a/R/sex_from_chi.R
+++ b/R/sex_from_chi.R
@@ -42,13 +42,13 @@
 sex_from_chi <- function(chi_number, male_value = 1L, female_value = 2L, as_factor = FALSE, chi_check = TRUE) {
 
   # Do type checking on male/female values
-  male_type <- class(male_value)
-  female_type <- class(female_value)
-  if (male_type != female_type) {
-    stop(paste0(
-      "Supplied male and female values must be of the same class ",
-      "(male_value is: ", male_type,
-      ", female_value is: ", female_type, ")."
+  male_class <- class(male_value)
+  female_class <- class(female_value)
+  if (male_class != female_class) {
+    cli::cli_abort(c(
+      "{.arg male_value} and {.arg female_value} must be of the same class.",
+      "*" = "Supplied {.arg male_value} is {.cls {male_class}}",
+      "*" = "Supplied {.arg female_value} is {.cls {female_class}}"
     ))
   }
 
@@ -57,7 +57,7 @@ sex_from_chi <- function(chi_number, male_value = 1L, female_value = 2L, as_fact
     message(paste0(
       "Using custom values: Male = ",
       male_value, " Female = ", female_value,
-      ".\nThe return variable will be ", male_type, "."
+      ".\nThe return variable will be ", male_class, "."
     ))
   }
 

--- a/R/sex_from_chi.R
+++ b/R/sex_from_chi.R
@@ -54,10 +54,9 @@ sex_from_chi <- function(chi_number, male_value = 1L, female_value = 2L, as_fact
 
   # Show message if using custom values for male/female
   if (male_value != 1L | female_value != 2L) {
-    message(paste0(
-      "Using custom values: Male = ",
-      male_value, " Female = ", female_value,
-      ".\nThe return variable will be ", male_class, "."
+    cli::cli_inform(c(
+      "Using custom values: Male = {.val {male_value}}, Female = {.val {female_value}}",
+      "The return variable will be {.cls {male_class}}."
     ))
   }
 

--- a/man/file_size.Rd
+++ b/man/file_size.Rd
@@ -74,7 +74,9 @@ file_size(pattern = "\\\\.xlsx$")
 
 # Size only of alphabetically first file in working directory
 library(magrittr)
-file_size() \%>\% dplyr::pull(size) \%>\% extract(1)
+file_size() \%>\%
+  dplyr::pull(size) \%>\%
+  extract(1)
 
 }
 \seealso{

--- a/man/qtr.Rd
+++ b/man/qtr.Rd
@@ -53,4 +53,5 @@ qtr(x)
 qtr_end(x, format = "short")
 qtr_next(x)
 qtr_prev(x, format = "short")
+
 }

--- a/tests/testthat/test-age_calculate.R
+++ b/tests/testthat/test-age_calculate.R
@@ -135,7 +135,7 @@ test_that("Return warning if age is less than 0", {
         "2020-01-01"
       )
     )
-  ), regexp = "There are ages less than 0")
+  ), regexp = "There are ages less than 0\\.$")
 })
 
 test_that("Return warning if age is greater than 130", {
@@ -154,7 +154,7 @@ test_that("Return warning if age is greater than 130", {
         "2020-01-01"
       )
     )
-  ), regexp = "There are ages greater than 130 years")
+  ), regexp = "There are ages greater than 130 years\\.$")
   expect_warning(age_calculate(as.Date(
     c(
       "1889-01-01",
@@ -170,5 +170,5 @@ test_that("Return warning if age is greater than 130", {
     )
   ),
   units = "months"
-  ), regexp = "There are ages greater than 130 years")
+  ), regexp = "There are ages greater than 130 years\\.$")
 })

--- a/tests/testthat/test-chi_check.R
+++ b/tests/testthat/test-chi_check.R
@@ -40,7 +40,7 @@ test_that("Length > 10 fails chi_check", {
 })
 
 test_that("Non-character input fails chi_check", {
-  expect_error(chi_check(123), "`x` must be a <character> vector, not a <numeric> vector\\.$")
+  expect_error(chi_check(123), "The input must be a <character> vector, not a <numeric> vector\\.$")
 })
 
 test_that("Zero day fails chi_check", {

--- a/tests/testthat/test-chi_check.R
+++ b/tests/testthat/test-chi_check.R
@@ -40,7 +40,7 @@ test_that("Length > 10 fails chi_check", {
 })
 
 test_that("Non-character input fails chi_check", {
-  expect_error(chi_check(123), "The input must be of character class")
+  expect_error(chi_check(123), "`x` must be a <character> vector, not a <numeric> vector\\.$")
 })
 
 test_that("Zero day fails chi_check", {

--- a/tests/testthat/test-chi_pad.R
+++ b/tests/testthat/test-chi_pad.R
@@ -19,7 +19,7 @@ test_that("> 10 character input not padded by chi_pad", {
 })
 
 test_that("Non-character input fails chi_pad", {
-  expect_error(chi_pad(123), "The input must be of character class")
+  expect_error(chi_pad(123), "`x` must be a <character> vector, not a <numeric> vector\\.$")
 })
 
 test_that("Vector entry works in chi_pad", {

--- a/tests/testthat/test-chi_pad.R
+++ b/tests/testthat/test-chi_pad.R
@@ -19,7 +19,7 @@ test_that("> 10 character input not padded by chi_pad", {
 })
 
 test_that("Non-character input fails chi_pad", {
-  expect_error(chi_pad(123), "`x` must be a <character> vector, not a <numeric> vector\\.$")
+  expect_error(chi_pad(123), "The input must be a <character> vector, not a <numeric> vector\\.$")
 })
 
 test_that("Vector entry works in chi_pad", {

--- a/tests/testthat/test-dob_from_chi.R
+++ b/tests/testthat/test-dob_from_chi.R
@@ -180,26 +180,26 @@ test_that("any max_date where it is a future date is changed to date of today", 
 
 test_that("dob_from_chi errors properly", {
   expect_error(dob_from_chi(1010101129),
-    regexp = "typeof\\(chi_number\\) == \"character\" is not TRUE"
+    regexp = "`chi_number` must be a <character> vector, not a <numeric> vector\\.$"
   )
 
   expect_error(dob_from_chi("0101625707",
     min_date = "01-01-2020"
   ),
-  regexp = "min_date must have Date or POSIXct class"
+  regexp = "`min_date` must be a <Date> or <POSIXct> vector, not a <character> vector\\.$"
   )
 
   expect_error(dob_from_chi("0101625707",
     max_date = "01-01-2020"
   ),
-  regexp = "max_date must have Date or POSIXct class"
+  regexp = "`max_date` must be a <Date> or <POSIXct> vector, not a <character> vector\\.$"
   )
 
   expect_error(dob_from_chi("0101625707",
     min_date = as.Date("2020-01-01"),
     max_date = as.Date("1930-01-01")
   ),
-  regexp = "min_date <= max_date is not TRUE"
+  regexp = "`max_date`, must always be greater than or equal to `min_date`\\.$"
   )
 })
 
@@ -325,25 +325,25 @@ test_that("Can supply different reference dates per CHI", {
 
 test_that("age_from_chi errors properly", {
   expect_error(age_from_chi(1010101129),
-    regexp = "typeof\\(chi_number\\) == \"character\" is not TRUE"
+    regexp = "`chi_number` must be a <character> vector, not a <numeric> vector\\.$"
   )
 
   expect_error(age_from_chi("0101625707",
     ref_date = "01-01-2020"
   ),
-  regexp = "ref_date must have Date or POSIXct class"
+  regexp = "`ref_date` must be a <Date> or <POSIXct> vector, not a <character> vector\\.$"
   )
 
   expect_error(age_from_chi("0101625707",
     min_age = -2
   ),
-  regexp = "min_age >= 0 is not TRUE"
+  regexp = "`min_age` must be a positive integer\\.$"
   )
 
   expect_error(age_from_chi("0101625707",
     min_age = 20, max_age = 10
   ),
-  regexp = "max_age >= min_age is not TRUE"
+  regexp = "`max_age`, must always be greater than or equal to `min_age`\\.$"
   )
 })
 

--- a/tests/testthat/test-dob_from_chi.R
+++ b/tests/testthat/test-dob_from_chi.R
@@ -174,7 +174,7 @@ test_that("any max_date where it is a future date is changed to date of today", 
   )
 
   expect_warning(dob_from_chi("0101336489", max_date = as.Date("2030-01-01")),
-    regexp = "any max_date where it is a future date is changed to date of today"
+    regexp = "Any `max_date` values which are in the future will be set to today: .*?$"
   )
 })
 

--- a/tests/testthat/test-dob_from_chi.R
+++ b/tests/testthat/test-dob_from_chi.R
@@ -9,7 +9,6 @@ gen_real_chi <- function(first_6) {
 }
 
 test_that("Returns correct DoB - no options", {
-
   # Some standard CHIs / dates
   expect_equal(
     dob_from_chi(c(
@@ -83,12 +82,11 @@ test_that("Returns correct DoB - unusual fixed dates", {
 })
 
 test_that("Returns NA when DoB is ambiguous", {
-
   # Default is min 1 Jan 1900, max today.
   # So any dates 1 Jan 2000 to today are 'ambiguous'
   expect_message(
     dob_from_chi(gen_real_chi(010101)),
-    regexp = "^1 CHI number produced an ambiguous date and will be given NA for DoB"
+    regexp = "1 CHI number produced an ambiguous date"
   )
 
   expect_message(
@@ -97,7 +95,7 @@ test_that("Returns NA when DoB is ambiguous", {
       gen_real_chi(010110),
       gen_real_chi(010120)
     )),
-    regexp = "^3 CHI numbers produced ambiguous dates and will be given NA for DoB"
+    regexp = "3 CHI numbers produced ambiguous dates"
   )
 
   expect_equal(
@@ -111,7 +109,6 @@ test_that("Returns NA when DoB is ambiguous", {
     as.Date(c(NA, NA, NA))
   )
 })
-
 
 test_that("Can supply different max dates per CHI", {
   # Some standard CHIs / dates
@@ -204,19 +201,17 @@ test_that("dob_from_chi errors properly", {
 })
 
 test_that("dob_from_chi gives messages when returning NA", {
-
   # Invalid CHI numbers
   expect_message(dob_from_chi("1234567890"),
-    regexp = "^1 CHI number was invalid and will be given NA for DoB"
+    regexp = "1 CHI number is invalid"
   )
 
   expect_message(dob_from_chi(rep("1234567890", 99999)),
-    regexp = "^99,999 CHI numbers were invalid and will be given NA for DoB"
+    regexp = "99,999 CHI numbers are invalid"
   )
 })
 
 test_that("Returns correct age - no options", {
-
   # Some standard CHIs
   expect_equal(
     age_from_chi(c(
@@ -276,11 +271,10 @@ test_that("Returns correct age - unusual fixed age", {
 })
 
 test_that("Returns NA when DoB is ambiguous so can't return age", {
-
   # Default is min_age as 0. max_age is NULL and will be set to the age from 1900-01-01.
   expect_message(
     age_from_chi(gen_real_chi(010101)),
-    regexp = "^1 CHI number produced an ambiguous date and will be given NA for DoB"
+    regexp = "1 CHI number produced an ambiguous date"
   )
 
   expect_message(
@@ -289,7 +283,7 @@ test_that("Returns NA when DoB is ambiguous so can't return age", {
       gen_real_chi(010110),
       gen_real_chi(010120)
     )),
-    regexp = "^3 CHI numbers produced ambiguous dates and will be given NA for DoB"
+    regexp = "3 CHI numbers produced ambiguous dates"
   )
 
   expect_equal(
@@ -348,13 +342,12 @@ test_that("age_from_chi errors properly", {
 })
 
 test_that("age_from_chi gives messages when returning NA", {
-
   # Invalid CHI numbers
   expect_message(age_from_chi("1234567890"),
-    regexp = "^1 CHI number was invalid and will be given NA for DoB"
+    regexp = "1 CHI number is invalid"
   )
 
   expect_message(age_from_chi(rep("1234567890", 99999)),
-    regexp = "^99,999 CHI numbers were invalid and will be given NA for DoB"
+    regexp = "99,999 CHI numbers are invalid"
   )
 })

--- a/tests/testthat/test-match_area.R
+++ b/tests/testthat/test-match_area.R
@@ -46,6 +46,6 @@ test_that("Produces no warning for codes of valid length with no match", {
 })
 
 test_that("Warns about the appropriate number of entries", {
-  expect_warning(match_area(123223), "^1")
-  expect_warning(match_area(c(NA, sprintf("RA270%d", seq(1:7)))), "^3")
+  expect_warning(match_area(123223), "1 non-NA input geography.*")
+  expect_warning(match_area(c(NA, paste0("RA270", 1:7))), "3 non-NA input geographies.*")
 })

--- a/tests/testthat/test-sex_from_chi.R
+++ b/tests/testthat/test-sex_from_chi.R
@@ -64,7 +64,7 @@ test_that("sex_from_chi works with custom values", {
     sex_from_chi("0101011237",
       male_value = "M"
     ),
-    "^Supplied male and female values must be of the same class.+?$"
+    "`male_value` and `female_value` must be of the same class\\..*?$"
   )
 
   expect_error(
@@ -72,7 +72,7 @@ test_that("sex_from_chi works with custom values", {
       male_value = 1,
       female_value = 2L
     ),
-    "^Supplied male and female values must be of the same class.+?$"
+    "`male_value` and `female_value` must be of the same class\\..*?$"
   )
 })
 


### PR DESCRIPTION
I've replaced all errors, warnings and messages I could find with equivalent code using the `cli` package.

The functionality of the package is unaffected, the only changes are to the output messages which should broadly look a bit nicer and be more helpful. Some replacements also make the code easier to read and therefore maintain as I've been able to use `cli`'s great [pluralisation](https://cli.r-lib.org/articles/pluralization.html) features.