### PR TITLE
Remove gdata dependency 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,13 +28,13 @@ Depends:
 Imports:
     cli,
     dplyr,
-    gdata,
     lifecycle,
     lubridate,
     magrittr,
     purrr,
     readr,
     rlang,
+    scales (>= 1.0.0),
     stringr,
     tibble,
     utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,4 +49,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/file_size.R
+++ b/R/file_size.R
@@ -84,41 +84,34 @@ file_size <- function(filepath = getwd(), pattern = NULL) {
     cli::cli_abort("{.arg pattern} must be a {.cls character}, not a {.cls {class(pattern)}}.")
   }
 
-  x <- dir(path = filepath, pattern = pattern)
+  file_list <- list.files(path = filepath, pattern = pattern)
 
-  if (length(x) == 0) {
+  if (length(file_list) == 0) {
     return(NULL)
   }
 
-  y <- x %>%
-    purrr::map_dbl(~ file.info(paste0(filepath, "/", .))$size) %>%
-    # The gdata package defines a kilobyte (KB) as 1,000 bytes, and a
-    # kibibyte (KiB) as 1,024 bytes
-    # In PHS a kilobyte is normally taken to be 1,024 bytes
-    # As a workaround, calculate file sizes in kibibytes (or higher), then
-    # drop the `i` from the output
-    gdata::humanReadable(standard = "IEC", digits = 0) %>%
-    gsub("i", "", .) %>%
-    trimws()
+  formatted_size <- file.path(filepath, file_list) %>%
+    file.size() %>%
+    scales::number_bytes(units = "si")
 
-  z <- dplyr::case_when(
-    stringr::str_detect(x, "\\.xls(b|m|x)?$") ~ "Excel ",
-    stringr::str_detect(x, "\\.csv$") ~ "CSV ",
-    stringr::str_detect(x, "\\.z?sav$") ~ "SPSS ",
-    stringr::str_detect(x, "\\.doc(m|x)?$") ~ "Word ",
-    stringr::str_detect(x, "\\.rds$") ~ "RDS ",
-    stringr::str_detect(x, "\\.txt$") ~ "Text ",
-    stringr::str_detect(x, "\\.fst$") ~ "FST ",
-    stringr::str_detect(x, "\\.pdf$") ~ "PDF ",
-    stringr::str_detect(x, "\\.tsv$") ~ "TSV ",
-    stringr::str_detect(x, "\\.html$") ~ "HTML ",
-    stringr::str_detect(x, "\\.ppt(m|x)?$") ~ "PowerPoint ",
-    stringr::str_detect(x, "\\.md$") ~ "Markdown ",
+  file_type <- dplyr::case_when(
+    stringr::str_detect(file_list, "\\.xls(b|m|x)?$") ~ "Excel ",
+    stringr::str_detect(file_list, "\\.csv$") ~ "CSV ",
+    stringr::str_detect(file_list, "\\.z?sav$") ~ "SPSS ",
+    stringr::str_detect(file_list, "\\.doc(m|x)?$") ~ "Word ",
+    stringr::str_detect(file_list, "\\.rds$") ~ "RDS ",
+    stringr::str_detect(file_list, "\\.txt$") ~ "Text ",
+    stringr::str_detect(file_list, "\\.fst$") ~ "FST ",
+    stringr::str_detect(file_list, "\\.pdf$") ~ "PDF ",
+    stringr::str_detect(file_list, "\\.tsv$") ~ "TSV ",
+    stringr::str_detect(file_list, "\\.html$") ~ "HTML ",
+    stringr::str_detect(file_list, "\\.ppt(m|x)?$") ~ "PowerPoint ",
+    stringr::str_detect(file_list, "\\.md$") ~ "Markdown ",
     TRUE ~ ""
   )
 
   tibble::tibble(
-    name = list.files(filepath, pattern),
-    size = paste0(z, y)
+    name = file_list,
+    size = paste0(file_type, formatted_size)
   )
 }

--- a/tests/testthat/_snaps/file_size.md
+++ b/tests/testthat/_snaps/file_size.md
@@ -1,0 +1,28 @@
+# Output is identical over time
+
+    Code
+      file_size(test_path("files"))
+    Output
+      # A tibble: 8 x 2
+        name             size       
+        <chr>            <chr>      
+      1 airquality.xls   Excel 26 kB
+      2 bod.xlsx         Excel 5 kB 
+      3 iris.csv         CSV 4 kB   
+      4 mtcars.sav       SPSS 4 kB  
+      5 plant-growth.rds RDS 316 B  
+      6 puromycin.txt    Text 418 B 
+      7 stackloss.fst    FST 897 B  
+      8 swiss.tsv        TSV 1 kB   
+
+---
+
+    Code
+      file_size(test_path("files"), "xlsx?")
+    Output
+      # A tibble: 2 x 2
+        name           size       
+        <chr>          <chr>      
+      1 airquality.xls Excel 26 kB
+      2 bod.xlsx       Excel 5 kB 
+

--- a/tests/testthat/test-file_size.R
+++ b/tests/testthat/test-file_size.R
@@ -1,5 +1,5 @@
 test_that("Returns a tibble", {
-  expect_true(tibble::is_tibble(file_size(test_path("files"))))
+  expect_s3_class(file_size(test_path("files")), "tbl")
 })
 
 test_that("Identifies correct number of files", {
@@ -10,11 +10,21 @@ test_that("Identifies correct number of files", {
 })
 
 test_that("Returns sizes with correct prefix", {
-  expect_true(stringr::str_detect(
-    file_size(test_path("files"), ".tsv$") %>%
+  expect_match(
+    file_size(test_path("files"), "tsv") %>%
       dplyr::pull(size),
-    "^TSV\\s[0-9]*\\s[A-Z]?B$"
-  ))
+    "^TSV 1 kB$"
+  )
+  expect_match(
+    file_size(test_path("files"), "csv") %>%
+      dplyr::pull(size),
+    "^CSV 4 kB$"
+  )
+  expect_match(
+    file_size(test_path("files"), "fst") %>%
+      dplyr::pull(size),
+    "^FST 897 B$"
+  )
 })
 
 test_that("Returns sizes in alphabetical order", {
@@ -25,6 +35,11 @@ test_that("Returns sizes in alphabetical order", {
       dplyr::arrange(name) %>%
       dplyr::pull(name)
   )
+})
+
+test_that("Output is identical over time", {
+  expect_snapshot(file_size(test_path("files")))
+  expect_snapshot(file_size(test_path("files"), "xlsx?"))
 })
 
 test_that("Errors if supplied with invalid filepath", {


### PR DESCRIPTION
Closes #91 

Just a quick PR to remove the `gdata` dependency, as it's causing issues with installing phsmethods on the new server. I've replaced it with the `scales` package in the one place it was used, and tidied up the code a little bit.