### PR TITLE
#90 Add a `quiet` parameter to `format_postcode` 

### DIFF
--- a/R/format_postcode.R
+++ b/R/format_postcode.R
@@ -77,7 +77,8 @@ format_postcode <- function(x, format = c("pc7", "pc8")) {
 
   # Calculate the number of non-NA values in the input which do not adhere to
   # the standard UK postcode format
-  n_bad_format <- sum(!stringr::str_detect(x, uk_pc_regex), na.rm = TRUE)
+  bad_format <- stringr::str_detect(x_upper, uk_pc_regex, negate = TRUE)
+  n_bad_format <- sum(bad_format, na.rm = TRUE)
 
   if (n_bad_format > 0) {
     cli::cli_warn(c(

--- a/R/format_postcode.R
+++ b/R/format_postcode.R
@@ -61,8 +61,11 @@
 #' df <- tibble(postcode = c("G429BA", "G207AL", "DD37JY", "DG98BS"))
 #' df %>% mutate(postcode = format_postcode(postcode))
 #' @export
-
 format_postcode <- function(x, format = c("pc7", "pc8")) {
+  if (!inherits(x, "character")) {
+    cli::cli_abort("The input must be a {.cls character} vector,
+                   not a {.cls {class(x)}} vector.")
+  }
   format <- match.arg(format)
 
   # The standard regex for a UK postcode

--- a/R/format_postcode.R
+++ b/R/format_postcode.R
@@ -33,11 +33,11 @@
 #' @param format A character string denoting the desired output format. Valid
 #' options are `pc7` and `pc8`. The default is `pc7`. See \strong{Value}
 #' section for more information on the string length of output values.
-#' @param quiet By default [format_postcode()] will give messages and warnings
-#' when the input contains unexpected values. If you are using this function to
-#' 'clean up' rather than 'check' postcodes and you know there will be lots of
-#' 'bad' values you can set `quiet` to `TRUE` to suppress messages. This will
-#' also make the function a bit quicker as fewer checks are performed.
+#' @param quite (optional) If quiet is `TRUE` all messages and warnings will be
+#' suppressed. This is useful in a production context and when you are sure of
+#' the data or you are specifically using this function to remove invalid
+#' postcodes. This will also make the function a bit quicker as fewer checks
+#' are performed.
 #'
 #' @return When \code{format} is set equal to \code{pc7}, \code{format_postcode}
 #' returns a character string of length 7. 5 character postcodes have two
@@ -129,12 +129,20 @@ format_postcode <- function(x, format = c("pc7", "pc8"), quiet = FALSE) {
   if (format == "pc7") {
     return(dplyr::case_when(
       is.na(x_upper) ~ NA_character_,
-      x_upper_len == 5 ~ paste0(substr(x_upper, 1, 2), "  ", substr(x_upper, 3, 5)),
-      x_upper_len == 6 ~ paste0(substr(x_upper, 1, 3), " ", substr(x_upper, 4, 6)),
+      x_upper_len == 5 ~ paste0(
+        substr(x_upper, 1, 2),
+        "  ",
+        substr(x_upper, 3, 5)
+      ),
+      x_upper_len == 6 ~ paste0(
+        substr(x_upper, 1, 3),
+        " ",
+        substr(x_upper, 4, 6)
+      ),
       x_upper_len == 7 ~ x_upper
     ))
   } else {
-    # pc8 format requires all valid postcodes to be of max_upperimum length 8
+    # pc8 format requires all valid postcodes to be of maximum length 8
     # All postcodes, whether 5, 6 or 7 characters, have one space before the
     # last 3 characters
     return(dplyr::case_when(

--- a/R/format_postcode.R
+++ b/R/format_postcode.R
@@ -19,9 +19,9 @@
 #' \href{https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/283357/ILRSpecification2013_14Appendix_C_Dec2012_v1.pdf}{UK government regulations}
 #' mandate which letters and numbers can be used in specific sections of a
 #' postcode. However, these regulations are liable to change over time. For
-#' this reason, \code{format_postcode} does not validate whether a given postcode
-#' actually exists, or whether specific numbers and letters are being used in
-#' the appropriate places. It only assesses whether the given input is
+#' this reason, \code{format_postcode} does not validate whether a given
+#' postcode actually exists, or whether specific numbers and letters are being
+#' used in the appropriate places. It only assesses whether the given input is
 #' consistent with the above format and, if so, assigns the appropriate amount
 #' of spacing and capitalises any lower case letters.
 #'
@@ -44,8 +44,8 @@
 #' spaces after the 2nd character; 6 character postcodes have 1 space after the
 #' 3rd character; and 7 character postcodes have no spaces.
 #'
-#' When \code{format} is set equal to \code{pc8}, \code{format_postcode} returns a
-#' character string with maximum length 8. All postcodes, whether 5, 6 or 7
+#' When \code{format} is set equal to \code{pc8}, \code{format_postcode} returns
+#'  a character string with maximum length 8. All postcodes, whether 5, 6 or 7
 #' characters, have one space before the last 3 characters.
 #'
 #' Any input values which do not adhere to the standard UK postcode format will
@@ -64,7 +64,8 @@
 #'
 #' library(dplyr)
 #' df <- tibble(postcode = c("G429BA", "G207AL", "DD37JY", "DG98BS"))
-#' df %>% mutate(postcode = format_postcode(postcode))
+#' df %>%
+#'   mutate(postcode = format_postcode(postcode))
 #' @export
 format_postcode <- function(x, format = c("pc7", "pc8"), quiet = FALSE) {
   if (!inherits(x, "character")) {

--- a/man/format_postcode.Rd
+++ b/man/format_postcode.Rd
@@ -4,7 +4,7 @@
 \alias{format_postcode}
 \title{Format a postcode}
 \usage{
-format_postcode(x, format = c("pc7", "pc8"))
+format_postcode(x, format = c("pc7", "pc8"), quiet = FALSE)
 }
 \arguments{
 \item{x}{A character string or vector of character strings. Input values
@@ -16,6 +16,12 @@ warning message - see \strong{Value} section for more information.}
 \item{format}{A character string denoting the desired output format. Valid
 options are `pc7` and `pc8`. The default is `pc7`. See \strong{Value}
 section for more information on the string length of output values.}
+
+\item{quiet}{By default [format_postcode()] will give messages and warnings
+when the input contains unexpected values. If you are using this function to
+'clean up' rather than 'check' postcodes and you know there will be lots of
+'bad' values you can set `quiet` to `TRUE` to suppress messages. This will
+also make the function a bit quicker as fewer checks are performed.}
 }
 \value{
 When \code{format} is set equal to \code{pc7}, \code{format_postcode}

--- a/man/format_postcode.Rd
+++ b/man/format_postcode.Rd
@@ -29,8 +29,8 @@ returns a character string of length 7. 5 character postcodes have two
 spaces after the 2nd character; 6 character postcodes have 1 space after the
 3rd character; and 7 character postcodes have no spaces.
 
-When \code{format} is set equal to \code{pc8}, \code{format_postcode} returns a
-character string with maximum length 8. All postcodes, whether 5, 6 or 7
+When \code{format} is set equal to \code{pc8}, \code{format_postcode} returns
+ a character string with maximum length 8. All postcodes, whether 5, 6 or 7
 characters, have one space before the last 3 characters.
 
 Any input values which do not adhere to the standard UK postcode format will
@@ -64,9 +64,9 @@ The standard UK postcode format (without spaces) is:
 \href{https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/283357/ILRSpecification2013_14Appendix_C_Dec2012_v1.pdf}{UK government regulations}
 mandate which letters and numbers can be used in specific sections of a
 postcode. However, these regulations are liable to change over time. For
-this reason, \code{format_postcode} does not validate whether a given postcode
-actually exists, or whether specific numbers and letters are being used in
-the appropriate places. It only assesses whether the given input is
+this reason, \code{format_postcode} does not validate whether a given
+postcode actually exists, or whether specific numbers and letters are being
+used in the appropriate places. It only assesses whether the given input is
 consistent with the above format and, if so, assigns the appropriate amount
 of spacing and capitalises any lower case letters.
 }
@@ -76,5 +76,6 @@ format_postcode(c("KA89NB", "PA152TY"), format = "pc8")
 
 library(dplyr)
 df <- tibble(postcode = c("G429BA", "G207AL", "DD37JY", "DG98BS"))
-df \%>\% mutate(postcode = format_postcode(postcode))
+df \%>\%
+  mutate(postcode = format_postcode(postcode))
 }

--- a/man/format_postcode.Rd
+++ b/man/format_postcode.Rd
@@ -17,11 +17,11 @@ warning message - see \strong{Value} section for more information.}
 options are `pc7` and `pc8`. The default is `pc7`. See \strong{Value}
 section for more information on the string length of output values.}
 
-\item{quiet}{By default [format_postcode()] will give messages and warnings
-when the input contains unexpected values. If you are using this function to
-'clean up' rather than 'check' postcodes and you know there will be lots of
-'bad' values you can set `quiet` to `TRUE` to suppress messages. This will
-also make the function a bit quicker as fewer checks are performed.}
+\item{quite}{(optional) If quiet is `TRUE` all messages and warnings will be
+suppressed. This is useful in a production context and when you are sure of
+the data or you are specifically using this function to remove invalid
+postcodes. This will also make the function a bit quicker as fewer checks
+are performed.}
 }
 \value{
 When \code{format} is set equal to \code{pc7}, \code{format_postcode}

--- a/tests/testthat/_snaps/format_postcode.md
+++ b/tests/testthat/_snaps/format_postcode.md
@@ -1,0 +1,67 @@
+# Warning gives true number of values that don't adhere to format
+
+    Code
+      format_postcode("g2")
+    Warning <rlang_warning>
+      1 value has lower case letters these will be converted to upper case.
+      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
+      The standard format is:
+      * 1 or 2 letters, followed by
+      * 1 number, followed by
+      * 1 optional letter or number, followed by
+      * 1 number, followed by
+      * 2 letters
+    Output
+      [1] NA
+
+---
+
+    Code
+      format_postcode(c("DG98BS", "dg98b"))
+    Warning <rlang_warning>
+      1 value has lower case letters these will be converted to upper case.
+      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
+      The standard format is:
+      * 1 or 2 letters, followed by
+      * 1 number, followed by
+      * 1 optional letter or number, followed by
+      * 1 number, followed by
+      * 2 letters
+    Output
+      [1] "DG9 8BS" NA       
+
+---
+
+    Code
+      format_postcode(c("ML53RB", NA, "ML5", "???", 53, as.factor("ML53RB")))
+    Warning <rlang_warning>
+      4 non-NA input values do not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
+      The standard format is:
+      * 1 or 2 letters, followed by
+      * 1 number, followed by
+      * 1 optional letter or number, followed by
+      * 1 number, followed by
+      * 2 letters
+    Output
+      [1] "ML5 3RB" NA        NA        NA        NA        NA       
+
+---
+
+    Code
+      format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!"), quiet = TRUE)
+    Output
+      [1] "KY1 1RZ" NA        NA        NA       
+    Code
+      format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!"), quiet = FALSE)
+    Warning <rlang_warning>
+      1 value has lower case letters these will be converted to upper case.
+      3 non-NA input values do not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
+      The standard format is:
+      * 1 or 2 letters, followed by
+      * 1 number, followed by
+      * 1 optional letter or number, followed by
+      * 1 number, followed by
+      * 2 letters
+    Output
+      [1] "KY1 1RZ" NA        NA        NA       
+

--- a/tests/testthat/_snaps/rename.md
+++ b/tests/testthat/_snaps/rename.md
@@ -80,16 +80,34 @@
     Warning <lifecycle_warning_deprecated>
       `postcode()` was deprecated in phsmethods 0.2.1.
       i Please use `format_postcode()` instead.
+    Warning <rlang_warning>
+      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
+      The standard format is:
+      * 1 or 2 letters, followed by
+      * 1 number, followed by
+      * 1 optional letter or number, followed by
+      * 1 number, followed by
+      * 2 letters
     Code
       expect_warning(postcode(c("DG98BS", "dg98b")), "^1")
     Warning <lifecycle_warning_deprecated>
       `postcode()` was deprecated in phsmethods 0.2.1.
       i Please use `format_postcode()` instead.
+    Warning <rlang_warning>
+      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
+      The standard format is:
+      * 1 or 2 letters, followed by
+      * 1 number, followed by
+      * 1 optional letter or number, followed by
+      * 1 number, followed by
+      * 2 letters
     Code
       expect_warning(postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!")), "^3")
     Warning <lifecycle_warning_deprecated>
       `postcode()` was deprecated in phsmethods 0.2.1.
       i Please use `format_postcode()` instead.
+    Warning <rlang_warning>
+      1 value has lower case letters these will be converted to upper case.
     Code
       expect_warning(postcode(c("ML53RB", NA, "ML5", "???", 53, as.factor("ML53RB"))),
       "^4")

--- a/tests/testthat/test-format_postcode.R
+++ b/tests/testthat/test-format_postcode.R
@@ -67,12 +67,12 @@ test_that("Output is the same with the quiet param set to TRUE", {
   )
 
   # Handles all valid outcode formats
-    expect_equal(format_postcode("G36RB", quiet = TRUE), "G3  6RB")
-    expect_equal(format_postcode("G432XR", quiet = TRUE), "G43 2XR")
-    expect_equal(format_postcode("DG29BA", quiet = TRUE), "DG2 9BA")
-    expect_equal(format_postcode("FK101RY", quiet = TRUE), "FK101RY")
-    expect_equal(format_postcode("E1W3TJ", quiet = TRUE), "E1W 3TJ")
-    expect_equal(format_postcode("EC1Y8SE", quiet = TRUE), "EC1Y8SE")
+  expect_equal(format_postcode("G36RB", quiet = TRUE), "G3  6RB")
+  expect_equal(format_postcode("G432XR", quiet = TRUE), "G43 2XR")
+  expect_equal(format_postcode("DG29BA", quiet = TRUE), "DG2 9BA")
+  expect_equal(format_postcode("FK101RY", quiet = TRUE), "FK101RY")
+  expect_equal(format_postcode("E1W3TJ", quiet = TRUE), "E1W 3TJ")
+  expect_equal(format_postcode("EC1Y8SE", quiet = TRUE), "EC1Y8SE")
 
   # Parses multiple input formats
   input_hampden <- c("G429BA", "g429ba", "G42 9BA", "G 4 2 9 B A", "G429b    a")
@@ -111,8 +111,7 @@ test_that("Warning gives true number of values that don't adhere to format", {
   expect_snapshot({
     format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!"), quiet = TRUE)
     format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!"), quiet = FALSE)
-  }
-  )
+  })
 })
 
 test_that("The quiet parameter suppresses messages correctly", {

--- a/tests/testthat/test-format_postcode.R
+++ b/tests/testthat/test-format_postcode.R
@@ -22,7 +22,7 @@ test_that("Parses multiple input formats", {
   input_hampden <- c("G429BA", "g429ba", "G42 9BA", "G 4 2 9 B A", "G429b    a")
   formatted_hampden <- suppressWarnings(format_postcode(input_hampden))
 
-  expect_true(length(unique(formatted_hampden)) == 1)
+  expect_length(unique(formatted_hampden), 1)
   expect_equal(unique(formatted_hampden), "G42 9BA")
 })
 
@@ -30,22 +30,22 @@ test_that("Correctly handles values which don't adhere to standard format", {
   expect_true(is.na(suppressWarnings(format_postcode("G2?QE"))))
   expect_warning(format_postcode(c("G207AL", "G2O07AL")))
   expect_equal(
-    suppressWarnings(format_postcode(c(
-      "EH7 5QG", NA,
-      "EH11 2NL", "EH5 2HF*"
-    ))),
+    suppressWarnings(format_postcode(
+      c("EH7 5QG", NA, "EH11 2NL", "EH5 2HF*")
+    )),
     c("EH7 5QG", NA, "EH112NL", NA)
   )
 })
 
 test_that("Produces correct number of warning messages", {
-  input_dens <- c("Dd37Jy", "DD37JY", "D  d 337JY")
-  warnings_dens <- capture_warnings(format_postcode(input_dens))
-  expect_length(warnings_dens, 1)
+  dens_postcodes <- c("Dd37Jy", "DD37JY", "D  d 337JY")
+  format_postcode(dens_postcodes) %>%
+    expect_warning()
 
-  input_pittodrie <- c("ab245qh", NA, "ab245q", "A  B245QH")
-  warnings_pittodrie <- capture_warnings(format_postcode(input_pittodrie))
-  expect_length(warnings_pittodrie, 2)
+  pittodrie_postcodes <- c("ab245qh", NA, "ab245q", "A  B245QH")
+  format_postcode(pittodrie_postcodes) %>%
+    expect_warning() %>%
+    expect_warning()
 })
 
 test_that("Warning gives true number of values that don't adhere to format", {

--- a/tests/testthat/test-format_postcode.R
+++ b/tests/testthat/test-format_postcode.R
@@ -1,12 +1,14 @@
 test_that("Creates strings of correct length", {
-  expect_equal(stringr::str_length(format_postcode("G26QE", format = "pc7")), 7)
-  expect_equal(stringr::str_length(format_postcode("G26QE", format = "pc8")), 6)
-  expect_equal(stringr::str_length(format_postcode(c("KA89NB", "PA152TY"),
-    format = "pc7"
-  )), c(7, 7))
-  expect_equal(stringr::str_length(format_postcode(c("KA89NB", "PA152TY"),
-    format = "pc8"
-  )), c(7, 8))
+  expect_equal(nchar(format_postcode("G26QE", format = "pc7")), 7)
+  expect_equal(nchar(format_postcode("G26QE", format = "pc8")), 6)
+  expect_equal(
+    nchar(format_postcode(c("KA89NB", "PA152TY"), format = "pc7")),
+    c(7, 7)
+  )
+  expect_equal(
+    nchar(format_postcode(c("KA89NB", "PA152TY"), format = "pc8")),
+    c(7, 8)
+  )
 })
 
 test_that("Handles all valid outcode formats", {
@@ -37,6 +39,57 @@ test_that("Correctly handles values which don't adhere to standard format", {
   )
 })
 
+test_that("Output is the same with the quiet param set to TRUE", {
+  # Creates strings of correct length
+  expect_equal(
+    nchar(format_postcode("G26QE", format = "pc7", quiet = TRUE)),
+    7
+  )
+  expect_equal(
+    nchar(format_postcode("G26QE", format = "pc8", quiet = TRUE)),
+    6
+  )
+  expect_equal(
+    nchar(format_postcode(
+      c("KA89NB", "PA152TY"),
+      format = "pc7",
+      quiet = TRUE
+    )),
+    c(7, 7)
+  )
+  expect_equal(
+    nchar(format_postcode(
+      c("KA89NB", "PA152TY"),
+      format = "pc8",
+      quiet = TRUE
+    )),
+    c(7, 8)
+  )
+
+  # Handles all valid outcode formats
+    expect_equal(format_postcode("G36RB", quiet = TRUE), "G3  6RB")
+    expect_equal(format_postcode("G432XR", quiet = TRUE), "G43 2XR")
+    expect_equal(format_postcode("DG29BA", quiet = TRUE), "DG2 9BA")
+    expect_equal(format_postcode("FK101RY", quiet = TRUE), "FK101RY")
+    expect_equal(format_postcode("E1W3TJ", quiet = TRUE), "E1W 3TJ")
+    expect_equal(format_postcode("EC1Y8SE", quiet = TRUE), "EC1Y8SE")
+
+  # Parses multiple input formats
+  input_hampden <- c("G429BA", "g429ba", "G42 9BA", "G 4 2 9 B A", "G429b    a")
+  formatted_hampden <- format_postcode(input_hampden, quiet = TRUE)
+
+  expect_length(unique(formatted_hampden), 1)
+  expect_equal(unique(formatted_hampden), "G42 9BA")
+
+  # Correctly handles values which don't adhere to standard format
+  expect_true(is.na(format_postcode("G2?QE", quiet = TRUE)))
+  expect_no_warning(format_postcode(c("G207AL", "G2O07AL"), quiet = TRUE))
+  expect_equal(
+    format_postcode(c("EH7 5QG", NA, "EH11 2NL", "EH5 2HF*"), quiet = TRUE),
+    c("EH7 5QG", NA, "EH112NL", NA)
+  )
+})
+
 test_that("Produces correct number of warning messages", {
   dens_postcodes <- c("Dd37Jy", "DD37JY", "D  d 337JY")
   format_postcode(dens_postcodes) %>%
@@ -49,14 +102,15 @@ test_that("Produces correct number of warning messages", {
 })
 
 test_that("Warning gives true number of values that don't adhere to format", {
-  expect_warning(format_postcode("g2"), "^1")
-  expect_warning(format_postcode(c("DG98BS", "dg98b")), "^1")
-  expect_warning(format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!")), "^3")
-  expect_warning(
-    format_postcode(c(
-      "ML53RB", NA, "ML5",
-      "???", 53, as.factor("ML53RB")
-    )),
-    "^4"
+  expect_snapshot(format_postcode("g2"))
+  expect_snapshot(format_postcode(c("DG98BS", "dg98b")))
+  expect_snapshot(
+    format_postcode(c("ML53RB", NA, "ML5", "???", 53, as.factor("ML53RB")))
+  )
+
+  expect_snapshot({
+    format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!"), quiet = TRUE)
+    format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!"), quiet = FALSE)
+  }
   )
 })

--- a/tests/testthat/test-format_postcode.R
+++ b/tests/testthat/test-format_postcode.R
@@ -114,3 +114,22 @@ test_that("Warning gives true number of values that don't adhere to format", {
   }
   )
 })
+
+test_that("The quiet parameter suppresses messages correctly", {
+  expect_equal(
+    format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!"), quiet = TRUE),
+    c("KY1 1RZ", NA, NA, NA)
+  )
+  expect_equal(
+    format_postcode(c("KY1 1RZ", "ky1 1rz"), quiet = TRUE),
+    c("KY1 1RZ", "KY1 1RZ")
+  )
+  expect_equal(
+    format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!"), quiet = TRUE),
+    suppressWarnings(format_postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!")))
+  )
+  expect_equal(
+    format_postcode(c("KY1 1RZ", "ky1 1rz"), quiet = TRUE),
+    suppressWarnings(format_postcode(c("KY1 1RZ", "ky1 1rz")))
+  )
+})


### PR DESCRIPTION
With this update, you have the option to use `quiet` to prevent the function from generating warnings. By default, warnings will be produced unless you set it to `TRUE`.

Closes #90 

I have also made several tweaks to speed up the code:

- Postcodes are made uppercase earlier. This means we can use a simpler (and faster) regex, it does, however, mean that the warnings about lowercase inputs will now always appear even if the input is invalid for a different reason: e.g. `james` would have previously returned `NA` with a warning about it being in an invalid format, that will still happen but now you will also get a warning saying it will be made upper case.
- The warning about lowercase values is now more informative with a count of the 'bad' values.
- I've simplified the removal of spaces by assuming it will only have spaces (and not tabs or other whitespace characters) in which case we don't need to use regex, which again is faster.
- For the final `case_when` I've removed the usage of regex replacement in favour of a hardcoded substring replacement, this works the same and is faster but is a bit more more long-winded to type!