### PR TITLE
A large speed up to `extract_fin_year`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # phsmethods (development version)
 
+- `extract_fin_year()` is now much faster and will use less memory, especially for smaller vectors (1 to 1,000).
+
 # phsmethods 0.2.2
 
 - Improve `chi_check()` function to make it more efficient and run faster.

--- a/R/extract_fin_year.R
+++ b/R/extract_fin_year.R
@@ -1,7 +1,7 @@
 #' @title Extract the formatted financial year from a date
 #'
-#' @description \code{extract_fin_year} takes a date and assigns it to the
-#' correct financial year in the PHS specified format.
+#' @description \code{extract_fin_year} takes a date and extracts the
+#' correct financial year in the PHS specified format from it.
 #'
 #' @details The PHS accepted format for financial year is YYYY/YY e.g. 2017/18.
 #'

--- a/R/extract_fin_year.R
+++ b/R/extract_fin_year.R
@@ -1,7 +1,7 @@
-#' @title Assign a date to a financial year
+#' @title Extract the formatted financial year from a date
 #'
-#' @description \code{extract_fin_year} takes a date and assigns it to the correct
-#' financial year in the PHS specified format.
+#' @description \code{extract_fin_year} takes a date and assigns it to the
+#' correct financial year in the PHS specified format.
 #'
 #' @details The PHS accepted format for financial year is YYYY/YY e.g. 2017/18.
 #'

--- a/R/extract_fin_year.R
+++ b/R/extract_fin_year.R
@@ -17,7 +17,8 @@
 #' @export
 extract_fin_year <- function(date) {
   if (!inherits(date, c("Date", "POSIXct"))) {
-    cli::cli_abort("{.arg date} must be a {.cls Date} or {.cls POSIXct} vector, not a {.cls {class(date)}} vector.")
+    cli::cli_abort("{.arg date} must be a {.cls Date} or {.cls POSIXct} vector,
+                   not a {.cls {class(date)}} vector.")
   }
 
   # Simply converting all elements of the input vector resulted in poor
@@ -26,29 +27,18 @@ extract_fin_year <- function(date) {
   # and then match them back on to the original input. This vastly improves
   # performance for large inputs.
 
-  x <- tibble::tibble(dates = unique(date)) %>%
-    dplyr::mutate(
-      fyear = paste0(
-        ifelse(lubridate::month(.data$dates) >= 4,
-          lubridate::year(.data$dates),
-          lubridate::year(.data$dates) - 1
-        ),
-        "/",
-        substr(
-          ifelse(lubridate::month(.data$dates) >= 4,
-            lubridate::year(.data$dates) + 1,
-            lubridate::year(.data$dates)
-          ),
-          3, 4
-        )
-      ),
-      fyear = ifelse(is.na(.data$dates),
-        NA_character_,
-        .data$fyear
-      )
-    )
+  unique_date <- unique(date)
 
-  tibble::tibble(dates = date) %>%
-    dplyr::left_join(x, by = "dates") %>%
-    dplyr::pull(.data$fyear)
+  unique_fy_q <-
+    lubridate::year(unique_date) - (lubridate::month(unique_date) %in% 1:3)
+
+  unique_fy <- ifelse(
+    is.na(unique_date),
+    NA_character_,
+    paste0(unique_fy_q, "/", (unique_fy_q %% 100L) + 1L)
+  )
+
+  fin_years <- unique_fy[match(date, unique_date)]
+
+  return(fin_years)
 }

--- a/man/extract_fin_year.Rd
+++ b/man/extract_fin_year.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/extract_fin_year.R
 \name{extract_fin_year}
 \alias{extract_fin_year}
-\title{Assign a date to a financial year}
+\title{Extract the formatted financial year from a date}
 \usage{
 extract_fin_year(date)
 }
@@ -14,8 +14,8 @@ class. \code{\link[base:as.Date]{as.Date()}},
 can be used to store dates as an appropriate class.}
 }
 \description{
-\code{extract_fin_year} takes a date and assigns it to the correct
-financial year in the PHS specified format.
+\code{extract_fin_year} takes a date and assigns it to the
+correct financial year in the PHS specified format.
 }
 \details{
 The PHS accepted format for financial year is YYYY/YY e.g. 2017/18.

--- a/man/extract_fin_year.Rd
+++ b/man/extract_fin_year.Rd
@@ -14,8 +14,8 @@ class. \code{\link[base:as.Date]{as.Date()}},
 can be used to store dates as an appropriate class.}
 }
 \description{
-\code{extract_fin_year} takes a date and assigns it to the
-correct financial year in the PHS specified format.
+\code{extract_fin_year} takes a date and extracts the
+correct financial year in the PHS specified format from it.
 }
 \details{
 The PHS accepted format for financial year is YYYY/YY e.g. 2017/18.


### PR DESCRIPTION
I was working on a similar function for one of my projects and realised the improvements I made there were also applicable here.

This is basically a full rewrite of the function but there is no change functionally (all the tests still pass).

This provides a speedup of 70X for a single date, and a 2X speedup for 10 million dates, scaling between those two numbers for other vector sizes! Importantly the changes also use 2.5-3X less memory.

```r
> bench::press(
+   n = c(1, 1e3, 1e5, 1e7),
+   {
+     dates <- create_dates(n)
+     bench::mark(
+      original = extract_fin_year(dates),
+      new = extract_fin_year_new(dates),
+      relative = TRUE,
+      min_time = 3
+     )
+   }
+ ) %>% 
+   print() %>% 
+   ggplot2::autoplot()
Running with:
         n
1        1
2     1000
3   100000
4 10000000
# A tibble: 8 × 14
  expression        n   min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result    memory     time      
  <bch:expr>    <dbl> <dbl>  <dbl>     <dbl>     <dbl>    <dbl> <int> <dbl>   <bch:tm> <list>    <list>     <list>    
1 original          1 71.3   69.1       1       Inf        1      776    15      2.84s <chr [2]> <Rprofmem> <bench_tm>
2 new               1  1      1        71.1     NaN        1.47  9996     4    515.3ms <chr [2]> <Rprofmem> <bench_tm>
3 original       1000 19.0   19.3       1         3.16     2.43   747    14      2.85s <chr>     <Rprofmem> <bench_tm>
4 new            1000  1      1        19.2       1        1     9996     4      1.98s <chr>     <Rprofmem> <bench_tm>
5 original     100000  2.17   2.05      1         2.77     4.09   223     4      2.91s <chr>     <Rprofmem> <bench_tm>
6 new          100000  1      1         2.16      1        1      493     1      2.98s <chr>     <Rprofmem> <bench_tm>
7 original   10000000  1.94   1.97      1         2.52     1.32     3     8      3.42s <chr>     <Rprofmem> <bench_tm>
8 new        10000000  1      1         2.02      1        1        6     6      3.38s <chr>     <Rprofmem> <bench_tm>
```
![image](https://github.com/Public-Health-Scotland/phsmethods/assets/5982260/5da973f2-35d9-4e54-90f8-44af5d8571dd)
