### PR TITLE
Update installation instructions in the README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -40,16 +40,29 @@ knitr::opts_chunk$set(
 If you are using the PHS Posit Workbench the default repository is the PHS Posit Package Manager, the benefit of this is that `phsmethods` is listed there so you can install it with:
 
 ``` r
-install.packaged("phsmethods")
+install.packages("phsmethods")
 ```
 
-To install `phsmethods` from directly from GitHub, the package `remotes` is required, and can be
+To install `phsmethods` directly from GitHub, the package `remotes` is required, and can be
 installed with `install.packages("remotes")`.
 
-You can then install `phsmethods` on RStudio server from GitHub with:
+You can then install `phsmethods` from GitHub with:
 
 ``` r
 remotes::install_github("Public-Health-Scotland/phsmethods")
+```
+
+However, network security settings may prevent `remotes::install_github()` from
+working on RStudio desktop. If this is the case, `phsmethods` can be
+installed by downloading the [zip of the
+repository](https://github.com/Public-Health-Scotland/phsmethods/archive/master.zip)
+and running the following code (replacing the section marked `<>`,
+including the arrows themselves):
+
+``` r
+remotes::install_local("<FILEPATH OF ZIPPED FILE>/phsmethods-master.zip",
+  upgrade = "never"
+)
 ```
 
 ## Using phsmethods

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,22 +37,19 @@ knitr::opts_chunk$set(
 
 ## Installation
 
-To install `phsmethods`, the package `remotes` is required, and can be installed with `install.packages("remotes")`.
+If you are using the PHS Posit Workbench the default repository is the PHS Posit Package Manager, the benefit of this is that `phsmethods` is listed there so you can install it with:
+
+``` r
+install.packaged("phsmethods")
+```
+
+To install `phsmethods` from directly from GitHub, the package `remotes` is required, and can be
+installed with `install.packages("remotes")`.
 
 You can then install `phsmethods` on RStudio server from GitHub with:
 
-```{r gh-installation, eval = FALSE}
-remotes::install_github("Public-Health-Scotland/phsmethods",
-  upgrade = "never"
-)
-```
-
-Network security settings may prevent `remotes::install_github()` from working on RStudio desktop. If this is the case, `phsmethods` can be installed by downloading the [zip of the repository](https://github.com/Public-Health-Scotland/phsmethods/archive/master.zip) and running the following code (replacing the section marked `<>`, including the arrows themselves):
-
-```{r source-installation, eval = FALSE}
-remotes::install_local("<FILEPATH OF ZIPPED FILE>/phsmethods-master.zip",
-  upgrade = "never"
-)
+``` r
+remotes::install_github("Public-Health-Scotland/phsmethods")
 ```
 
 ## Using phsmethods

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ Status](https://github.com/Public-Health-Scotland/phsmethods/workflows/R-CMD-che
 in [Public Health Scotland
 (PHS)](https://www.publichealthscotland.scot/):
 
--   `create_age_groups()` categorises ages into groups
--   `chi_check()` assesses the validity of a CHI number
--   `chi_pad()` adds a leading zero to nine-digit CHI numbers
--   `sex_from_chi()` extracts the sex of a person from a CHI number
--   `file_size()` returns the names and sizes of files in a directory
--   `extract_fin_year()` assigns a date to a financial year in the
-    format `YYYY/YY`
--   `match_area()` converts geography codes into area names
--   `format_postcode()` formats improperly recorded postcodes
--   `qtr()`, `qtr_end()`, `qtr_next()` and `qtr_prev()` assign a date to
-    a quarter
--   `age_calculate()` calculates age between two dates
--   `dob_from_chi()` extracts Date of Birth (DoB) from the CHI number
--   `age_from_chi()` extracts age from the CHI number
+- `create_age_groups()` categorises ages into groups
+- `chi_check()` assesses the validity of a CHI number
+- `chi_pad()` adds a leading zero to nine-digit CHI numbers
+- `sex_from_chi()` extracts the sex of a person from a CHI number
+- `file_size()` returns the names and sizes of files in a directory
+- `extract_fin_year()` assigns a date to a financial year in the format
+  `YYYY/YY`
+- `match_area()` converts geography codes into area names
+- `format_postcode()` formats improperly recorded postcodes
+- `qtr()`, `qtr_end()`, `qtr_next()` and `qtr_prev()` assign a date to a
+  quarter
+- `age_calculate()` calculates age between two dates
+- `dob_from_chi()` extracts Date of Birth (DoB) from the CHI number
+- `age_from_chi()` extracts age from the CHI number
 
 `phsmethods` can be used on both the
 [server](https://rstudio.nhsnss.scot.nhs.uk/) and desktop versions of
@@ -141,17 +141,17 @@ guide](https://style.tidyverse.org/) and the [rOpenSci package
 development guide](https://devguide.ropensci.org/). The most pertinent
 points to take from these are:
 
--   All function names should be in lower case, with words separated by
-    an underscore
--   Put a space after a comma, never before
--   Put a space before and after infix operators such as `<-`, `==` and
-    `+`
--   Limit code to 80 characters per line
--   Function documentation should be generated using
-    [`roxygen2`](https://github.com/r-lib/roxygen2)
--   All functions should be tested using
-    [`testthat`](https://github.com/r-lib/testthat)
--   The package should always pass `devtools::check()`
+- All function names should be in lower case, with words separated by an
+  underscore
+- Put a space after a comma, never before
+- Put a space before and after infix operators such as `<-`, `==` and
+  `+`
+- Limit code to 80 characters per line
+- Function documentation should be generated using
+  [`roxygen2`](https://github.com/r-lib/roxygen2)
+- All functions should be tested using
+  [`testthat`](https://github.com/r-lib/testthat)
+- The package should always pass `devtools::check()`
 
 It’s not necessary to have experience with GitHub or of building an R
 package to contribute to `phsmethods`. If you wish to contribute code

--- a/README.md
+++ b/README.md
@@ -34,28 +34,21 @@ RStudio.
 
 ## Installation
 
-To install `phsmethods`, the package `remotes` is required, and can be
-installed with `install.packages("remotes")`.
+If you are using the PHS Posit Workbench the default repository is the
+PHS Posit Package Manager, the benefit of this is that `phsmethods` is
+listed there so you can install it with:
+
+``` r
+install.packaged("phsmethods")
+```
+
+To install `phsmethods` from directly from GitHub, the package `remotes`
+is required, and can be installed with `install.packages("remotes")`.
 
 You can then install `phsmethods` on RStudio server from GitHub with:
 
 ``` r
-remotes::install_github("Public-Health-Scotland/phsmethods",
-  upgrade = "never"
-)
-```
-
-Network security settings may prevent `remotes::install_github()` from
-working on RStudio desktop. If this is the case, `phsmethods` can be
-installed by downloading the [zip of the
-repository](https://github.com/Public-Health-Scotland/phsmethods/archive/master.zip)
-and running the following code (replacing the section marked `<>`,
-including the arrows themselves):
-
-``` r
-remotes::install_local("<FILEPATH OF ZIPPED FILE>/phsmethods-master.zip",
-  upgrade = "never"
-)
+remotes::install_github("Public-Health-Scotland/phsmethods")
 ```
 
 ## Using phsmethods


### PR DESCRIPTION
I've deleted the bit about downloading the source and installing it as I don't think that's relevant anymore - PHS VPN / RStudio Desktop can install from GitHub, as can the PHS PWB.

I also added a note that using the PHS PPM we can just use `install.packages`