### PR TITLE
Deprecate the renamed functions.

### DIFF
--- a/R/rename.R
+++ b/R/rename.R
@@ -4,9 +4,9 @@
 #' `r lifecycle::badge('deprecated')`
 #'
 #' phsmethods 0.2.1 renamed a number of functions
-#' to improve code clarity. The old functions will still
-#' work but will produce a warning. After a reasonable
-#' amount of time they will be removed completely.
+#' to improve code clarity. The old functions no longer
+#' work and will error. At the next update they will be
+#' removed completely.
 #'
 #' * `postcode()` -> `format_postcode()`
 #' * `age_group()` -> `create_age_groups()`
@@ -21,7 +21,7 @@ NULL
 #' @rdname rename
 #' @export
 postcode <- function(x, format = c("pc7", "pc8")) {
-  lifecycle::deprecate_warn("0.2.1", "postcode()", "format_postcode()")
+  lifecycle::deprecate_stop("0.2.1", "postcode()", "format_postcode()")
 
   return(format_postcode(x = x, format = format))
 }
@@ -33,7 +33,7 @@ age_group <- function(x,
                       to = 90,
                       by = 5,
                       as_factor = FALSE) {
-  lifecycle::deprecate_warn("0.2.1", "age_group()", "create_age_groups()")
+  lifecycle::deprecate_stop("0.2.1", "age_group()", "create_age_groups()")
 
   return(create_age_groups(
     x = x,
@@ -47,7 +47,7 @@ age_group <- function(x,
 #' @rdname rename
 #' @export
 fin_year <- function(date) {
-  lifecycle::deprecate_warn("0.2.1", "fin_year()", "extract_fin_year()")
+  lifecycle::deprecate_stop("0.2.1", "fin_year()", "extract_fin_year()")
 
   return(extract_fin_year(date = date))
 }

--- a/man/rename.Rd
+++ b/man/rename.Rd
@@ -16,9 +16,9 @@ fin_year(date)
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
 phsmethods 0.2.1 renamed a number of functions
-to improve code clarity. The old functions will still
-work but will produce a warning. After a reasonable
-amount of time they will be removed completely.
+to improve code clarity. The old functions no longer
+work and will error. At the next update they will be
+removed completely.
 \itemize{
 \item \code{postcode()} -> \code{format_postcode()}
 \item \code{age_group()} -> \code{create_age_groups()}

--- a/tests/testthat/_snaps/rename.md
+++ b/tests/testthat/_snaps/rename.md
@@ -2,117 +2,126 @@
 
     Code
       expect_equal(stringr::str_length(postcode("G26QE", format = "pc7")), 7)
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(stringr::str_length(postcode("G26QE", format = "pc8")), 6)
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(stringr::str_length(postcode(c("KA89NB", "PA152TY"), format = "pc7")),
       c(7, 7))
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(stringr::str_length(postcode(c("KA89NB", "PA152TY"), format = "pc8")),
       c(7, 8))
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(postcode("G36RB"), "G3  6RB")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(postcode("G432XR"), "G43 2XR")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(postcode("DG29BA"), "DG2 9BA")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(postcode("FK101RY"), "FK101RY")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(postcode("E1W3TJ"), "E1W 3TJ")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       expect_equal(postcode("EC1Y8SE"), "EC1Y8SE")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
     Code
       input_hampden <- c("G429BA", "g429ba", "G42 9BA", "G 4 2 9 B A", "G429b    a")
       formatted_hampden <- suppressWarnings(postcode(input_hampden))
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
+      i Please use `format_postcode()` instead.
+    Code
       expect_true(length(unique(formatted_hampden)) == 1)
+    Error <simpleError>
+      object 'formatted_hampden' not found
+    Code
       expect_equal(unique(formatted_hampden), "G42 9BA")
+    Error <simpleError>
+      object 'formatted_hampden' not found
+    Code
       expect_true(is.na(suppressWarnings(postcode("G2?QE"))))
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
+      i Please use `format_postcode()` instead.
+    Code
       expect_warning(postcode(c("G207AL", "G2O07AL")))
-    Warning <rlang_warning>
-      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
-      The standard format is:
-      * 1 or 2 letters, followed by
-      * 1 number, followed by
-      * 1 optional letter or number, followed by
-      * 1 number, followed by
-      * 2 letters
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
+      i Please use `format_postcode()` instead.
     Code
       expect_equal(suppressWarnings(postcode(c("EH7 5QG", NA, "EH11 2NL", "EH5 2HF*"))),
       c("EH7 5QG", NA, "EH112NL", NA))
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
+      i Please use `format_postcode()` instead.
+    Code
       input_dens <- c("Dd37Jy", "DD37JY", "D  d 337JY")
       warnings_dens <- capture_warnings(postcode(input_dens))
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
+      i Please use `format_postcode()` instead.
+    Code
       expect_length(warnings_dens, 2)
+    Error <simpleError>
+      object 'warnings_dens' not found
+    Code
       input_pittodrie <- c("ab245qh", NA, "ab245q", "A  B245QH")
       warnings_pittodrie <- capture_warnings(postcode(input_pittodrie))
-      expect_length(warnings_pittodrie, 3)
-      expect_warning(postcode("g2"), "^1")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
-    Warning <rlang_warning>
-      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
-      The standard format is:
-      * 1 or 2 letters, followed by
-      * 1 number, followed by
-      * 1 optional letter or number, followed by
-      * 1 number, followed by
-      * 2 letters
+    Code
+      expect_length(warnings_pittodrie, 3)
+    Error <simpleError>
+      object 'warnings_pittodrie' not found
+    Code
+      expect_warning(postcode("g2"), "^1")
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
+      i Please use `format_postcode()` instead.
     Code
       expect_warning(postcode(c("DG98BS", "dg98b")), "^1")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
-    Warning <rlang_warning>
-      1 non-NA input value does not adhere to the standard UK postcode format (with or without spaces) and will be coded as NA.
-      The standard format is:
-      * 1 or 2 letters, followed by
-      * 1 number, followed by
-      * 1 optional letter or number, followed by
-      * 1 number, followed by
-      * 2 letters
     Code
       expect_warning(postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!")), "^3")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
-    Warning <rlang_warning>
-      1 value has lower case letters these will be converted to upper case.
     Code
       expect_warning(postcode(c("ML53RB", NA, "ML5", "???", 53, as.factor("ML53RB"))),
       "^4")
-    Warning <lifecycle_warning_deprecated>
-      `postcode()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `postcode()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `format_postcode()` instead.
 
 # age_group is deprecated
@@ -120,8 +129,8 @@
     Code
       expect_identical(age_group(c(4, 51, 21, 89), 0, 80, 10, as_factor = FALSE), c(
         "0-9", "50-59", "20-29", "80+"))
-    Warning <lifecycle_warning_deprecated>
-      `age_group()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `age_group()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `create_age_groups()` instead.
     Code
       expect_identical(age_group(c(8, 94, 44, 55, 14), 0, 90, 5, as_factor = TRUE),
@@ -129,105 +138,82 @@
         "10-14", "15-19", "20-24", "25-29", "30-34", "35-39", "40-44", "45-49",
         "50-54", "55-59", "60-64", "65-69", "70-74", "75-79", "80-84", "85-89", "90+"),
       ordered = TRUE))
-    Warning <lifecycle_warning_deprecated>
-      `age_group()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `age_group()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `create_age_groups()` instead.
     Code
       expect_identical(age_group(c(81, 86, 33, 11), 4, 84, 3, as_factor = FALSE), c(
         "79-81", "82+", "31-33", "10-12"))
-    Warning <lifecycle_warning_deprecated>
-      `age_group()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `age_group()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `create_age_groups()` instead.
     Code
       expect_identical(age_group(c(0, 99, 1000, 5, 5), 5, 90, 5, as_factor = FALSE),
       c(NA, "90+", "90+", "5-9", "5-9"))
-    Warning <lifecycle_warning_deprecated>
-      `age_group()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `age_group()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `create_age_groups()` instead.
     Code
       expect_identical(age_group(10, as_factor = TRUE), factor(c("10-14"), levels = c(
         "0-4", "5-9", "10-14", "15-19", "20-24", "25-29", "30-34", "35-39", "40-44",
         "45-49", "50-54", "55-59", "60-64", "65-69", "70-74", "75-79", "80-84",
         "85-89", "90+"), ordered = TRUE))
-    Warning <lifecycle_warning_deprecated>
-      `age_group()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `age_group()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `create_age_groups()` instead.
     Code
       expect_error(age_group(c("1", "57", "apple", "12"), as_factor = FALSE))
-    Warning <lifecycle_warning_deprecated>
-      `age_group()` was deprecated in phsmethods 0.2.1.
-      i Please use `create_age_groups()` instead.
-    Code
       expect_error(age_group(c("26", "9", "78", "81"), as_factor = FALSE))
-    Warning <lifecycle_warning_deprecated>
-      `age_group()` was deprecated in phsmethods 0.2.1.
-      i Please use `create_age_groups()` instead.
 
 # fin_year is deprecated
 
     Code
       expect_equal(fin_year(as.Date("20120331", "%Y%m%d")), "2011/12")
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
     Code
       expect_equal(fin_year(as.Date("20120401", "%Y%m%d")), "2012/13")
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
     Code
       expect_equal(fin_year(as.POSIXct("20190104", format = "%Y%m%d")), "2018/19")
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
     Code
       expect_equal(fin_year(as.Date("17111993", "%d%m%Y")), "1993/94")
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
     Code
       expect_equal(fin_year(as.Date("19980404", "%Y%m%d")), "1998/99")
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
     Code
       expect_equal(fin_year(as.Date("21-Jan-2017", "%d-%B-%Y")), "2016/17")
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
     Code
       expect_equal(fin_year(as.POSIXct("20181401", format = "%Y%d%m")), "2017/18")
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
     Code
       expect_equal(fin_year(lubridate::dmy(29102019)), "2019/20")
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
     Code
       expect_error(fin_year("28102019"))
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
-      i Please use `extract_fin_year()` instead.
-    Code
       expect_error(fin_year("28-Oct-2019"))
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
-      i Please use `extract_fin_year()` instead.
-    Code
       expect_error(fin_year(as.numeric("28102019")))
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
-      i Please use `extract_fin_year()` instead.
-    Code
       expect_error(fin_year(as.factor("28-Oct-2019")))
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
-      i Please use `extract_fin_year()` instead.
-    Code
       expect_equal(fin_year(c(lubridate::dmy(5012020), NA)), c("2019/20", NA))
-    Warning <lifecycle_warning_deprecated>
-      `fin_year()` was deprecated in phsmethods 0.2.1.
+    Error <lifecycle_error_deprecated>
+      `fin_year()` was deprecated in phsmethods 0.2.1 and is now defunct.
       i Please use `extract_fin_year()` instead.
 

--- a/tests/testthat/test-rename.R
+++ b/tests/testthat/test-rename.R
@@ -50,7 +50,8 @@ test_that("postcode is deprecated", {
       )),
       "^4"
     )
-  })
+  },
+  error = TRUE)
 })
 
 test_that("age_group is deprecated", {
@@ -114,7 +115,8 @@ test_that("age_group is deprecated", {
 
     # This is true even if all elements are numbers stored as character
     expect_error(age_group(c("26", "9", "78", "81"), as_factor = FALSE))
-  })
+  },
+  error = TRUE)
 })
 
 test_that("fin_year is deprecated", {
@@ -135,5 +137,6 @@ test_that("fin_year is deprecated", {
     expect_error(fin_year(as.factor("28-Oct-2019")))
 
     expect_equal(fin_year(c(lubridate::dmy(05012020), NA)), c("2019/20", NA))
-  })
+  },
+  error = TRUE)
 })

--- a/tests/testthat/test-rename.R
+++ b/tests/testthat/test-rename.R
@@ -1,142 +1,148 @@
 test_that("postcode is deprecated", {
-  expect_snapshot({
-    expect_equal(stringr::str_length(postcode("G26QE", format = "pc7")), 7)
-    expect_equal(stringr::str_length(postcode("G26QE", format = "pc8")), 6)
-    expect_equal(stringr::str_length(postcode(c("KA89NB", "PA152TY"),
-      format = "pc7"
-    )), c(7, 7))
-    expect_equal(stringr::str_length(postcode(c("KA89NB", "PA152TY"),
-      format = "pc8"
-    )), c(7, 8))
+  expect_snapshot(
+    {
+      expect_equal(stringr::str_length(postcode("G26QE", format = "pc7")), 7)
+      expect_equal(stringr::str_length(postcode("G26QE", format = "pc8")), 6)
+      expect_equal(stringr::str_length(postcode(c("KA89NB", "PA152TY"),
+        format = "pc7"
+      )), c(7, 7))
+      expect_equal(stringr::str_length(postcode(c("KA89NB", "PA152TY"),
+        format = "pc8"
+      )), c(7, 8))
 
-    expect_equal(postcode("G36RB"), "G3  6RB")
-    expect_equal(postcode("G432XR"), "G43 2XR")
-    expect_equal(postcode("DG29BA"), "DG2 9BA")
-    expect_equal(postcode("FK101RY"), "FK101RY")
-    expect_equal(postcode("E1W3TJ"), "E1W 3TJ")
-    expect_equal(postcode("EC1Y8SE"), "EC1Y8SE")
+      expect_equal(postcode("G36RB"), "G3  6RB")
+      expect_equal(postcode("G432XR"), "G43 2XR")
+      expect_equal(postcode("DG29BA"), "DG2 9BA")
+      expect_equal(postcode("FK101RY"), "FK101RY")
+      expect_equal(postcode("E1W3TJ"), "E1W 3TJ")
+      expect_equal(postcode("EC1Y8SE"), "EC1Y8SE")
 
-    input_hampden <- c("G429BA", "g429ba", "G42 9BA", "G 4 2 9 B A", "G429b    a")
-    formatted_hampden <- suppressWarnings(postcode(input_hampden))
+      input_hampden <- c("G429BA", "g429ba", "G42 9BA", "G 4 2 9 B A", "G429b    a")
+      formatted_hampden <- suppressWarnings(postcode(input_hampden))
 
-    expect_true(length(unique(formatted_hampden)) == 1)
-    expect_equal(unique(formatted_hampden), "G42 9BA")
+      expect_true(length(unique(formatted_hampden)) == 1)
+      expect_equal(unique(formatted_hampden), "G42 9BA")
 
-    expect_true(is.na(suppressWarnings(postcode("G2?QE"))))
-    expect_warning(postcode(c("G207AL", "G2O07AL")))
-    expect_equal(
-      suppressWarnings(postcode(c(
-        "EH7 5QG", NA,
-        "EH11 2NL", "EH5 2HF*"
-      ))),
-      c("EH7 5QG", NA, "EH112NL", NA)
-    )
+      expect_true(is.na(suppressWarnings(postcode("G2?QE"))))
+      expect_warning(postcode(c("G207AL", "G2O07AL")))
+      expect_equal(
+        suppressWarnings(postcode(c(
+          "EH7 5QG", NA,
+          "EH11 2NL", "EH5 2HF*"
+        ))),
+        c("EH7 5QG", NA, "EH112NL", NA)
+      )
 
-    input_dens <- c("Dd37Jy", "DD37JY", "D  d 337JY")
-    warnings_dens <- capture_warnings(postcode(input_dens))
-    expect_length(warnings_dens, 2)
+      input_dens <- c("Dd37Jy", "DD37JY", "D  d 337JY")
+      warnings_dens <- capture_warnings(postcode(input_dens))
+      expect_length(warnings_dens, 2)
 
-    input_pittodrie <- c("ab245qh", NA, "ab245q", "A  B245QH")
-    warnings_pittodrie <- capture_warnings(postcode(input_pittodrie))
-    expect_length(warnings_pittodrie, 3)
+      input_pittodrie <- c("ab245qh", NA, "ab245q", "A  B245QH")
+      warnings_pittodrie <- capture_warnings(postcode(input_pittodrie))
+      expect_length(warnings_pittodrie, 3)
 
-    expect_warning(postcode("g2"), "^1")
-    expect_warning(postcode(c("DG98BS", "dg98b")), "^1")
-    expect_warning(postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!")), "^3")
-    expect_warning(
-      postcode(c(
-        "ML53RB", NA, "ML5",
-        "???", 53, as.factor("ML53RB")
-      )),
-      "^4"
-    )
-  },
-  error = TRUE)
+      expect_warning(postcode("g2"), "^1")
+      expect_warning(postcode(c("DG98BS", "dg98b")), "^1")
+      expect_warning(postcode(c("KY1 1RZ", "ky1rz", "KY11 R", "KY11R!")), "^3")
+      expect_warning(
+        postcode(c(
+          "ML53RB", NA, "ML5",
+          "???", 53, as.factor("ML53RB")
+        )),
+        "^4"
+      )
+    },
+    error = TRUE
+  )
 })
 
 test_that("age_group is deprecated", {
-  expect_snapshot({
-    expect_identical(
-      age_group(c(4, 51, 21, 89),
-        0, 80, 10,
-        as_factor = FALSE
-      ),
-      c("0-9", "50-59", "20-29", "80+")
-    )
-
-    expect_identical(
-      age_group(c(8, 94, 44, 55, 14),
-        0, 90, 5,
-        as_factor = TRUE
-      ),
-      factor(c("5-9", "90+", "40-44", "55-59", "10-14"),
-        levels = c(
-          "0-4", "5-9", "10-14", "15-19", "20-24", "25-29", "30-34",
-          "35-39", "40-44", "45-49", "50-54", "55-59", "60-64",
-          "65-69", "70-74", "75-79", "80-84", "85-89", "90+"
+  expect_snapshot(
+    {
+      expect_identical(
+        age_group(c(4, 51, 21, 89),
+          0, 80, 10,
+          as_factor = FALSE
         ),
-        ordered = TRUE
+        c("0-9", "50-59", "20-29", "80+")
       )
-    )
 
-    expect_identical(
-      age_group(c(81, 86, 33, 11),
-        4, 84, 3,
-        as_factor = FALSE
-      ),
-      c("79-81", "82+", "31-33", "10-12")
-    )
-
-    expect_identical(
-      age_group(c(0, 99, 1000, 5, 5),
-        5, 90, 5,
-        as_factor = FALSE
-      ),
-      c(NA, "90+", "90+", "5-9", "5-9")
-    )
-
-    expect_identical(
-      age_group(10, as_factor = TRUE),
-      factor(c("10-14"),
-        levels = c(
-          "0-4", "5-9", "10-14", "15-19", "20-24", "25-29", "30-34",
-          "35-39", "40-44", "45-49", "50-54", "55-59", "60-64",
-          "65-69", "70-74", "75-79", "80-84", "85-89", "90+"
+      expect_identical(
+        age_group(c(8, 94, 44, 55, 14),
+          0, 90, 5,
+          as_factor = TRUE
         ),
-        ordered = TRUE
+        factor(c("5-9", "90+", "40-44", "55-59", "10-14"),
+          levels = c(
+            "0-4", "5-9", "10-14", "15-19", "20-24", "25-29", "30-34",
+            "35-39", "40-44", "45-49", "50-54", "55-59", "60-64",
+            "65-69", "70-74", "75-79", "80-84", "85-89", "90+"
+          ),
+          ordered = TRUE
+        )
       )
-    )
+
+      expect_identical(
+        age_group(c(81, 86, 33, 11),
+          4, 84, 3,
+          as_factor = FALSE
+        ),
+        c("79-81", "82+", "31-33", "10-12")
+      )
+
+      expect_identical(
+        age_group(c(0, 99, 1000, 5, 5),
+          5, 90, 5,
+          as_factor = FALSE
+        ),
+        c(NA, "90+", "90+", "5-9", "5-9")
+      )
+
+      expect_identical(
+        age_group(10, as_factor = TRUE),
+        factor(c("10-14"),
+          levels = c(
+            "0-4", "5-9", "10-14", "15-19", "20-24", "25-29", "30-34",
+            "35-39", "40-44", "45-49", "50-54", "55-59", "60-64",
+            "65-69", "70-74", "75-79", "80-84", "85-89", "90+"
+          ),
+          ordered = TRUE
+        )
+      )
 
 
 
 
-    # If x is not numeric cut will error
-    expect_error(age_group(c("1", "57", "apple", "12"), as_factor = FALSE))
+      # If x is not numeric cut will error
+      expect_error(age_group(c("1", "57", "apple", "12"), as_factor = FALSE))
 
-    # This is true even if all elements are numbers stored as character
-    expect_error(age_group(c("26", "9", "78", "81"), as_factor = FALSE))
-  },
-  error = TRUE)
+      # This is true even if all elements are numbers stored as character
+      expect_error(age_group(c("26", "9", "78", "81"), as_factor = FALSE))
+    },
+    error = TRUE
+  )
 })
 
 test_that("fin_year is deprecated", {
-  expect_snapshot({
-    expect_equal(fin_year(as.Date("20120331", "%Y%m%d")), "2011/12")
-    expect_equal(fin_year(as.Date("20120401", "%Y%m%d")), "2012/13")
-    expect_equal(fin_year(as.POSIXct("20190104", format = "%Y%m%d")), "2018/19")
+  expect_snapshot(
+    {
+      expect_equal(fin_year(as.Date("20120331", "%Y%m%d")), "2011/12")
+      expect_equal(fin_year(as.Date("20120401", "%Y%m%d")), "2012/13")
+      expect_equal(fin_year(as.POSIXct("20190104", format = "%Y%m%d")), "2018/19")
 
-    expect_equal(fin_year(as.Date("17111993", "%d%m%Y")), "1993/94")
-    expect_equal(fin_year(as.Date("19980404", "%Y%m%d")), "1998/99")
-    expect_equal(fin_year(as.Date("21-Jan-2017", "%d-%B-%Y")), "2016/17")
-    expect_equal(fin_year(as.POSIXct("20181401", format = "%Y%d%m")), "2017/18")
-    expect_equal(fin_year(lubridate::dmy(29102019)), "2019/20")
+      expect_equal(fin_year(as.Date("17111993", "%d%m%Y")), "1993/94")
+      expect_equal(fin_year(as.Date("19980404", "%Y%m%d")), "1998/99")
+      expect_equal(fin_year(as.Date("21-Jan-2017", "%d-%B-%Y")), "2016/17")
+      expect_equal(fin_year(as.POSIXct("20181401", format = "%Y%d%m")), "2017/18")
+      expect_equal(fin_year(lubridate::dmy(29102019)), "2019/20")
 
-    expect_error(fin_year("28102019"))
-    expect_error(fin_year("28-Oct-2019"))
-    expect_error(fin_year(as.numeric("28102019")))
-    expect_error(fin_year(as.factor("28-Oct-2019")))
+      expect_error(fin_year("28102019"))
+      expect_error(fin_year("28-Oct-2019"))
+      expect_error(fin_year(as.numeric("28102019")))
+      expect_error(fin_year(as.factor("28-Oct-2019")))
 
-    expect_equal(fin_year(c(lubridate::dmy(05012020), NA)), c("2019/20", NA))
-  },
-  error = TRUE)
+      expect_equal(fin_year(c(lubridate::dmy(05012020), NA)), c("2019/20", NA))
+    },
+    error = TRUE
+  )
 })


### PR DESCRIPTION
They will now throw an informative error, instead of the current behaviour where they will throw a warning but also return the expected result.

The tests have also been updated such that they now expect these functions to error.