### PR TITLE
Fix the file size test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,6 @@ Imports:
     utils
 Suggests: 
     covr,
-    here,
     spelling,
     testthat (>= 3.0.0)
 RdMacros: 

--- a/tests/testthat/_snaps/UNIX/file_size.md
+++ b/tests/testthat/_snaps/UNIX/file_size.md
@@ -1,0 +1,28 @@
+# Output is identical over time
+
+    Code
+      file_size(test_path("files"))
+    Output
+      # A tibble: 8 x 2
+        name             size       
+        <chr>            <chr>      
+      1 airquality.xls   Excel 26 kB
+      2 bod.xlsx         Excel 5 kB 
+      3 iris.csv         CSV 4 kB   
+      4 mtcars.sav       SPSS 4 kB  
+      5 plant-growth.rds RDS 316 B  
+      6 puromycin.txt    Text 418 B 
+      7 stackloss.fst    FST 897 B  
+      8 swiss.tsv        TSV 1 kB   
+
+---
+
+    Code
+      file_size(test_path("files"), "xlsx?")
+    Output
+      # A tibble: 2 x 2
+        name           size       
+        <chr>          <chr>      
+      1 airquality.xls Excel 26 kB
+      2 bod.xlsx       Excel 5 kB 
+

--- a/tests/testthat/_snaps/windows/file_size.md
+++ b/tests/testthat/_snaps/windows/file_size.md
@@ -11,7 +11,7 @@
       3 iris.csv         CSV 4 kB   
       4 mtcars.sav       SPSS 4 kB  
       5 plant-growth.rds RDS 316 B  
-      6 puromycin.txt    Text 418 B 
+      6 puromycin.txt    Text 442 B 
       7 stackloss.fst    FST 897 B  
       8 swiss.tsv        TSV 1 kB   
 

--- a/tests/testthat/test-file_size.R
+++ b/tests/testthat/test-file_size.R
@@ -38,8 +38,15 @@ test_that("Returns sizes in alphabetical order", {
 })
 
 test_that("Output is identical over time", {
-  expect_snapshot(file_size(test_path("files")))
-  expect_snapshot(file_size(test_path("files"), "xlsx?"))
+  # Text files report as larger on Windows so snapshot per OS
+  os <- ifelse(
+    "windows" %in% tolower(Sys.info()[["sysname"]]),
+    "windows",
+    "UNIX"
+  )
+
+  expect_snapshot(file_size(test_path("files")), variant = os)
+  expect_snapshot(file_size(test_path("files"), "xlsx?"), variant = os)
 })
 
 test_that("Errors if supplied with invalid filepath", {

--- a/tests/testthat/test-file_size.R
+++ b/tests/testthat/test-file_size.R
@@ -43,7 +43,7 @@ test_that("Output is identical over time", {
 })
 
 test_that("Errors if supplied with invalid filepath", {
-  expect_error(file_size(here::here("reference_files")))
+  expect_error(file_size(test_path("reference_files")))
   expect_error(file_size(NA))
   expect_error(file_size(NULL))
 })


### PR DESCRIPTION
I added some tests to `file_size`, these were reporting fine but failed on Windows as the text file was read to be larger than it had been on Linux (PWB).

This answer describes the issue - [https://www.unix.com/.../41059-file-size-different-unix-windows.html](https://www.unix.com/unix-for-dummies-questions-and-answers/41059-file-size-different-unix-windows.html#:~:text=Unix%20text%20file%20end%20each,13421%20%2D%2013292%20%3D%20129%20lines.)

My solution is to check the OS the test is running on (Windows or not) and create a specific snapshot based on that. This means there will still be a difference in the reported file size between Windows/non-Windows but the test will be useful to see if anything else changes accidentally.