### PR TITLE
Update the workflows with new R checked versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,15 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, dev]
+    branches:
+      - 'main'
+      - 'master'
+      - 'dev**'
   pull_request:
-    branches: [main, master, dev]
+    branches:
+      - 'main'
+      - 'master'
+      - 'dev**'
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,16 +29,19 @@ jobs:
           - {os: ubuntu-latest,   r: 'release', must_pass: true}
 
           # Development and recent releases
-          - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', must_pass: false}
-          - {os: ubuntu-latest, r: 'oldrel-1', must_pass: true}
-          - {os: ubuntu-latest, r: 'oldrel-2', must_pass: true}
+          - {os: windows-latest, r: 'devel', http-user-agent: 'release', must_pass: true}
+          - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', must_pass: true}
+          - {os: ubuntu-latest, r: 'oldrel-1', must_pass: false}
+          - {os: ubuntu-latest, r: 'oldrel-2', must_pass: false}
 
           # An approximation for the PHS RStudio Desktop installation
           - {os: windows-latest,  r: '3.6.1', must_pass: true}
+          - {os: windows-latest,  r: '4.0.1', must_pass: true}
 
-          # An approximation of the PHS RStudio Server Pro setup
+          # An approximation of the PHS RStudio setup on Posit Workbench
           - {os: ubuntu-latest,   r: '3.6.1', must_pass: true}
-          - {os: ubuntu-latest,   r: '3.5.1', must_pass: false}
+          - {os: ubuntu-latest,   r: '4.0.2', must_pass: true}
+          - {os: ubuntu-latest,   r: '4.1.2', must_pass: true}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,15 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, dev]
+    branches:
+      - 'main'
+      - 'master'
+      - 'dev**'
   pull_request:
-    branches: [main, master, dev]
+    branches:
+      - 'main'
+      - 'master'
+      - 'dev**'
 
 name: lint
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,13 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, dev]
+    branches:
+      - 'main'
+      - 'master'
   pull_request:
-    branches: [main, master, dev]
+      - 'main'
+      - 'master'
+      - 'dev**'
 
 name: test-coverage
 


### PR DESCRIPTION
Updating these to more closely match:
 1. The versions checked by CRAN.
 2. The current PHS RStudio Desktop install.
 3. The current PHS Post Workbench setup.

There is also a change so that they will run against any PR to dev or development (i.e. as long as the branch name starts with dev)