### PR TITLE
Add a `\value` to rename.Rd

### DIFF
--- a/R/rename.R
+++ b/R/rename.R
@@ -15,7 +15,7 @@
 #' @keywords internal
 #' @name rename
 #' @aliases NULL
-#' @return NULL
+#' @returns `r lifecycle::badge('deprecated')`
 NULL
 
 #' @rdname rename

--- a/man/rename.Rd
+++ b/man/rename.Rd
@@ -12,6 +12,9 @@ age_group(x, from = 0, to = 90, by = 5, as_factor = FALSE)
 
 fin_year(date)
 }
+\value{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 


### PR DESCRIPTION
I don't really like this as it doesn't make any sense.

It's also not consistent with the tidyverse advice: https://lifecycle.r-lib.org/articles/communicate.html#rename-a-function

or the example they show (rvest) - https://github.com/tidyverse/rvest/blob/HEAD/R/rename.R https://github.com/tidyverse/rvest/blob/0cda79b4671bab46ba5717c8658ff81030091281/man/rename.Rd

However, I'm pretty sure it should satisfy CRAN's requirements.