### PR TITLE
Add a `format` argument to `extract_fin_year()`

### DIFF
--- a/R/extract_fin_year.R
+++ b/R/extract_fin_year.R
@@ -27,11 +27,7 @@ extract_fin_year <- function(date, format = c("full", "numeric")) {
                    not a {.cls {class(date)}} vector.")
   }
 
-  if (missing(format)) {
-    format <- "full"
-  } else {
-    format <- match.arg(format)
-  }
+  format <- rlang::arg_match(format)
 
   if (inherits(date, "POSIXlt")) {
     posix <- date

--- a/man/extract_fin_year.Rd
+++ b/man/extract_fin_year.Rd
@@ -4,7 +4,7 @@
 \alias{extract_fin_year}
 \title{Extract the formatted financial year from a date}
 \usage{
-extract_fin_year(date)
+extract_fin_year(date, format = c("full", "numeric"))
 }
 \arguments{
 \item{date}{A date which must be supplied with \code{Date}, \code{POSIXct}, \code{POSIXlt} or
@@ -12,6 +12,12 @@ extract_fin_year(date)
 \code{\link[lubridate:ymd]{lubridate::dmy()}} and
 \code{\link[base:as.POSIXlt]{as.POSIXct()}} are examples of functions which
 can be used to store dates as an appropriate class.}
+
+\item{format}{The format to return the Financial Year
+\itemize{
+\item (Default) As a character vector in the form '2017/18'
+\item As an integer e.g. 2017 for '2017/18'.
+}}
 }
 \value{
 A character vector of financial years in the form '2017/18'.


### PR DESCRIPTION
This argument keeps the default format (so existing code will work without modification) and allows for choosing a numeric (integer) output.

I would find this useful, as I've been needing to do exactly this recently, not sure if we want to add it to this function though, so I've opened it as a draft.

If you think it's a worthwhile inclusion (and in this function), then I still need to:

- [ ] Add some tests.
- [ ] Properly update the documentation.