### PR TITLE
PHS domain update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Description: A collection of methods for commonly undertaken analytical
     data manipulation and analysis more efficient and reproducible.
 License: GPL (>= 2)
 URL: https://github.com/Public-Health-Scotland/phsmethods,
-    https://public-health-scotland.github.io/phsmethods/
+    https://code.publichealthscotland.scot/phsmethods
 BugReports: https://github.com/Public-Health-Scotland/phsmethods/issues
 Depends:
     R (>= 3.6)

--- a/README.Rmd
+++ b/README.Rmd
@@ -98,7 +98,7 @@ To see the documentation for any `phsmethods`' functions, type
 
 You can access the full list of functions and their help pages on
 [Reference page of pkgdown
-website](https://public-health-scotland.github.io/phsmethods/reference/index.html).
+website](https://code.publichealthscotland.scot/phsmethods/reference/index.html).
 You will be able to see some examples of each function.
 
 There is also a very useful [PHS Methods on-line training
@@ -149,7 +149,7 @@ and code commentary. For more information on security when using git and
 GitHub, and on using git and GitHub for version control more generally,
 please see the [Transforming Publishing
 Programme](https://www.isdscotland.org/Products-and-Services/Transforming-Publishing-Programme/)'s
-[Git guide](https://Public-Health-Scotland.github.io/git-guide/) and
+[Git guide](https://code.publichealthscotland.scot/git-guide/) and
 [GitHub
 guidance](https://github.com/Public-Health-Scotland/GitHub-guidance).
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To see the documentation for any `phsmethods`’ functions, type
 
 You can access the full list of functions and their help pages on
 [Reference page of pkgdown
-website](https://public-health-scotland.github.io/phsmethods/reference/index.html).
+website](https://code.publichealthscotland.scot/phsmethods/reference/index.html).
 You will be able to see some examples of each function.
 
 There is also a very useful [PHS Methods on-line training
@@ -139,7 +139,7 @@ and code commentary. For more information on security when using git and
 GitHub, and on using git and GitHub for version control more generally,
 please see the [Transforming Publishing
 Programme](https://www.isdscotland.org/Products-and-Services/Transforming-Publishing-Programme/)’s
-[Git guide](https://Public-Health-Scotland.github.io/git-guide/) and
+[Git guide](https://code.publichealthscotland.scot/git-guide/) and
 [GitHub
 guidance](https://github.com/Public-Health-Scotland/GitHub-guidance).
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://public-health-scotland.github.io/phsmethods/
+url: https://code.publichealthscotland.scot/phsmethods/
 template:
   bootstrap: 5
 

--- a/man/phsmethods-package.Rd
+++ b/man/phsmethods-package.Rd
@@ -12,7 +12,7 @@ A collection of methods for commonly undertaken analytical tasks, primarily deve
 Useful links:
 \itemize{
   \item \url{https://github.com/Public-Health-Scotland/phsmethods}
-  \item \url{https://public-health-scotland.github.io/phsmethods/}
+  \item \url{https://code.publichealthscotland.scot/phsmethods}
   \item Report bugs at \url{https://github.com/Public-Health-Scotland/phsmethods/issues}
 }
 


### PR DESCRIPTION
Updates to URLs now that PHS has a verified domain. https://code.publichealthscotland.scot 

The GitHub-hosted pkgdown site is currently redirecting from  https://public-health-scotland.github.io/phsmethods/ to https://code.publichealthscotland.scot/phsmethods, so any older links will still work (for example in NEWS.md).

https://teams.microsoft.com/l/message/19:meeting_MjIzYTQ5ZjgtMWJmOS00NjdkLWFhMTctNTI5YjRlNWRjMmE0@thread.v2/1787729818843?context=%7B%22contextType%22%3A%22chat%22%7D