### PR TITLE
Add chi_check to chi_pad

### DIFF
--- a/R/chi_pad.R
+++ b/R/chi_pad.R
@@ -18,6 +18,10 @@
 #' numeric values are silently dropped, a practice not exclusive to R. For this
 #' reason, `chi_pad` accepts input values of `character` class
 #' only, and returns values of the same class.
+#' @param chi_check logical, optionally check the CHI for validity (after
+#' padding), any invalid CHIs will be substituted with `NA`. The default (FALSE)
+#' will skip checking but we recommend you check any padded CHIs.This uses
+#' [chi_check()].
 #'
 #' @inheritParams chi_check
 #'

--- a/R/chi_pad.R
+++ b/R/chi_pad.R
@@ -17,8 +17,7 @@
 #' stored with `numeric` class in R. This is because leading zeros in
 #' numeric values are silently dropped, a practice not exclusive to R. For this
 #' reason, `chi_pad` accepts input values of `character` class
-#' only, and returns values of the same class. It does not assess the validity
-#' of a CHI number - please see [chi_check()] for that.
+#' only, and returns values of the same class.
 #'
 #' @inheritParams chi_check
 #'
@@ -27,12 +26,40 @@
 #' @examples
 #' chi_pad(c("101011237", "101201234"))
 #' @export
-chi_pad <- function(chi_number) {
+chi_pad <- function(chi_number, 
+                    chi_check = FALSE,
+                    check_mod11 = TRUE, 
+                    check_mod10 = TRUE) {
+
   if (!inherits(chi_number, "character")) {
     cli::cli_abort(
       "{.arg chi_number} must be a {.cls character} vector, not a {.cls {class(chi_number)}} vector."
     )
   }
-  # Add a leading zero to any string comprised of nine numeric digits
-  sub("^([0-9]{9})$", "0\\1", chi_number)
+  
+  # Pad the 9-digit numbers first
+  needs_padding <- nchar(chi_number) == 9 & !is.na(chi_number)
+  chi_number[needs_padding] <- paste0("0", chi_number[needs_padding])
+  
+  # Check the CHI after padding
+  if (chi_check) {
+    na_count <- sum(is.na(chi_number))
+    valid_chi <- chi_check(
+      chi_number, 
+      check_mod11 = check_mod11, 
+      check_mod10 = check_mod10
+    ) == "Valid CHI"
+    
+    chi_number[!valid_chi] <- NA_character_
+
+    new_na_count <- sum(is.na(chi_number)) - na_count
+
+    if (new_na_count > 0) {
+      cli::cli_alert_warning(
+        "{format(new_na_count, big.mark = ',')} {cli::qty(new_na_count)} CHI number{?s} {?is/are} invalid even after padding and will be set as {.val NA}."
+      )
+    }
+  }
+  
+  return(chi_number)
 }

--- a/R/chi_pad.R
+++ b/R/chi_pad.R
@@ -26,30 +26,29 @@
 #' @examples
 #' chi_pad(c("101011237", "101201234"))
 #' @export
-chi_pad <- function(chi_number, 
+chi_pad <- function(chi_number,
                     chi_check = FALSE,
-                    check_mod11 = TRUE, 
+                    check_mod11 = TRUE,
                     check_mod10 = TRUE) {
-
   if (!inherits(chi_number, "character")) {
     cli::cli_abort(
       "{.arg chi_number} must be a {.cls character} vector, not a {.cls {class(chi_number)}} vector."
     )
   }
-  
+
   # Pad the 9-digit numbers first
   needs_padding <- nchar(chi_number) == 9 & !is.na(chi_number)
   chi_number[needs_padding] <- paste0("0", chi_number[needs_padding])
-  
+
   # Check the CHI after padding
   if (chi_check) {
     na_count <- sum(is.na(chi_number))
     valid_chi <- chi_check(
-      chi_number, 
-      check_mod11 = check_mod11, 
+      chi_number,
+      check_mod11 = check_mod11,
       check_mod10 = check_mod10
     ) == "Valid CHI"
-    
+
     chi_number[!valid_chi] <- NA_character_
 
     new_na_count <- sum(is.na(chi_number)) - na_count
@@ -60,6 +59,6 @@ chi_pad <- function(chi_number,
       )
     }
   }
-  
+
   return(chi_number)
 }

--- a/R/chi_pad.R
+++ b/R/chi_pad.R
@@ -26,10 +26,12 @@
 #' @examples
 #' chi_pad(c("101011237", "101201234"))
 #' @export
-chi_pad <- function(chi_number,
-                    chi_check = FALSE,
-                    check_mod11 = TRUE,
-                    check_mod10 = TRUE) {
+chi_pad <- function(
+  chi_number,
+  chi_check = FALSE,
+  check_mod11 = TRUE,
+  check_mod10 = TRUE
+) {
   if (!inherits(chi_number, "character")) {
     cli::cli_abort(
       "{.arg chi_number} must be a {.cls character} vector, not a {.cls {class(chi_number)}} vector."
@@ -37,8 +39,9 @@ chi_pad <- function(chi_number,
   }
 
   # Pad the 9-digit numbers first
-  needs_padding <- nchar(chi_number) == 9 & !is.na(chi_number)
-  chi_number[needs_padding] <- paste0("0", chi_number[needs_padding])
+  if (any(nchar(chi_number) == 9L, na.rm = TRUE)) {
+    chi_number <- sub("^([0-9]{9})$", "0\\1", chi_number, perl = TRUE)
+  }
 
   # Check the CHI after padding
   if (chi_check) {
@@ -47,7 +50,8 @@ chi_pad <- function(chi_number,
       chi_number,
       check_mod11 = check_mod11,
       check_mod10 = check_mod10
-    ) == "Valid CHI"
+    ) ==
+      "Valid CHI"
 
     chi_number[!valid_chi] <- NA_character_
 

--- a/man/chi_pad.Rd
+++ b/man/chi_pad.Rd
@@ -4,10 +4,15 @@
 \alias{chi_pad}
 \title{Add a leading zero to nine-digit CHI numbers}
 \usage{
-chi_pad(chi_number)
+chi_pad(chi_number, chi_check = FALSE, check_mod11 = TRUE, check_mod10 = TRUE)
 }
 \arguments{
 \item{chi_number}{a CHI number or a vector of CHI numbers with \code{character} class.}
+
+\item{check_mod11, check_mod10}{Logical values (TRUE or FALSE, default is \code{TRUE}). By default, a CHI that passes either the modulo 10 or the modulo 11 check will be considered valid. Historically, CHIs only used modulo 11 for their check digit; however, starting in August 2026, some CHIs will only pass if they meet the modulo 10 criteria.
+Implementation of Mod 10 CHI numbers is scheduled for August 2026.
+From this date, CHI numbers are valid if they pass either a Mod 11 check
+or a Mod 10 check.}
 }
 \value{
 The original character vector with CHI numbers padded if applicable.
@@ -31,8 +36,7 @@ While a CHI number is made up exclusively of numeric digits, it cannot be
 stored with \code{numeric} class in R. This is because leading zeros in
 numeric values are silently dropped, a practice not exclusive to R. For this
 reason, \code{chi_pad} accepts input values of \code{character} class
-only, and returns values of the same class. It does not assess the validity
-of a CHI number - please see \code{\link[=chi_check]{chi_check()}} for that.
+only, and returns values of the same class.
 }
 \examples{
 chi_pad(c("101011237", "101201234"))

--- a/man/chi_pad.Rd
+++ b/man/chi_pad.Rd
@@ -9,6 +9,11 @@ chi_pad(chi_number, chi_check = FALSE, check_mod11 = TRUE, check_mod10 = TRUE)
 \arguments{
 \item{chi_number}{a CHI number or a vector of CHI numbers with \code{character} class.}
 
+\item{chi_check}{logical, optionally check the CHI for validity (after
+padding), any invalid CHIs will be substituted with \code{NA}. The default (FALSE)
+will skip checking but we recommend you check any padded CHIs.This uses
+\code{\link[=chi_check]{chi_check()}}.}
+
 \item{check_mod11, check_mod10}{Logical values (TRUE or FALSE, default is \code{TRUE}). By default, a CHI that passes either the modulo 10 or the modulo 11 check will be considered valid. Historically, CHIs only used modulo 11 for their check digit; however, starting in August 2026, some CHIs will only pass if they meet the modulo 10 criteria.
 Implementation of Mod 10 CHI numbers is scheduled for August 2026.
 From this date, CHI numbers are valid if they pass either a Mod 11 check


### PR DESCRIPTION
The function now accepts additional parameters for validation checks. It also includes warnings for invalid CHI numbers after padding.

I left `chi_check` as `FALSE` to maintain backwards compatibility, but there's an argument for it being on by default, as there's no value to padding a CHI and it still being invalid.

Closes #184 